### PR TITLE
templated bit ordering for BitSequence class

### DIFF
--- a/Implementation/Int Encoding/BitSequence.h
+++ b/Implementation/Int Encoding/BitSequence.h
@@ -34,12 +34,65 @@ typedef unsigned char byte;
  * TODO:
  * - change char pointer into generic char iterator
  */
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+class BitSequence;
 
-template <bool ENDIAN>
+//*
+// COMPARISON OPERATORS
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+std::ptrdiff_t operator-(
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+	);
+
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+bool operator<(
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+	);
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+bool operator<=(
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+	);
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+bool operator>(
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+	);
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+bool operator>=(
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+	);
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+bool operator==(
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+	);
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
+bool operator!=(
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+		const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+	);
+//*/
+
+template <bool ENDIAN_LITTLE, bool BITS_L2M>
 class BitSequence {
 private:
-	static const bool FWD=true;
-	static const bool REV=false;
+	friend BitSequence<ENDIAN_LITTLE,!BITS_L2M>;
+	friend bool operator==<ENDIAN_LITTLE,BITS_L2M>(
+			const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+			const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+		);
+	friend std::ptrdiff_t operator-<ENDIAN_LITTLE,BITS_L2M>(
+			const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq1,
+			const BitSequence<ENDIAN_LITTLE,BITS_L2M>& bseq2
+		);
+
+	static inline bool BYTES_ASCENDING() {
+		return ENDIAN_LITTLE == BITS_L2M;
+	}
 
 	byte subindex;
 	byte* p_index;
@@ -52,35 +105,30 @@ private:
 	 * Generic Methods that provide an abstraction independent of
 	 *	endianness and assignment direction
 	 */
-	// Returns the MBYTE resulting from bit-shifting 'value' forward 'n'
-	//	positions
-	template <bool DIRECTION, typename MBYTE>
-	static inline MBYTE fwd_shift(MBYTE value, std::ptrdiff_t n);
 	// Returns the stream-ordered bit position of the next bit
-	template <bool DIRECTION>
 	inline std::size_t fwd_subindex() const;
 	// Moves the bit pointer to the stream-ordered 'n'th bit position
-	template <bool DIRECTION>
 	inline void set_fwd_subindex(std::size_t n);
 	// Returns the MBYTE containing the next bit and the maximum number of
 	//	following bits (i.e. the next bit will be in the "first" byte of the
 	//	MBYTE, but not necessarily in the "first" bit position)
-	template <bool DIRECTION, typename MBYTE>
+	template <typename MBYTE>
 	inline MBYTE& fwd_mbyte();
+	// Returns the MBYTE resulting from bit-shifting 'value' forward 'n'
+	//	positions
+	template <typename MBYTE>
+	static inline MBYTE fwd_shift(MBYTE value, std::ptrdiff_t n);
 
 	// Returns the number of bytes remaining in the stream
 	inline std::ptrdiff_t bytes_left() const;
 	// Increments the byte pointer "forward" 'n' positions
-	template <bool DIRECTION>
 	inline void fwd_inc_p_index(std::size_t n);
 
 	// Returns the number of bytes overlapped with the next 'bitcount' bits
 	//	in the stream
-	template <bool DIRECTION>
 	inline std::size_t bytes_covered_by_next_bits(std::size_t bitcount) const;
 
 	// Skips the next 'bitcount' bits in the stream
-	template <bool DIRECTION>
 	inline void fwd_skip_next(std::size_t bitcount);
 
 
@@ -91,7 +139,7 @@ public:
 	//BitSequence(const BitSequence<ENDIAN>& rhs);
 	void init(byte* begin, byte* end);
 
-	operator bool();
+	operator bool() const;
 	inline std::size_t bits_left() const;
 	bool has_next() const;
 	bool has_next(std::size_t bitcount) const;
@@ -132,7 +180,7 @@ public:
 
 private:
 	template <typename MBYTE>
-	static MBYTE first_1bit(MBYTE value);
+	static inline std::size_t fwd_subindex_first_1bit(MBYTE value);
 	// Function that is looped inside the 'get' method
 	template <typename MBYTE>
 	bool get_streak_loopfunc(bool bit, std::size_t& bitcount);
@@ -140,10 +188,10 @@ private:
 	template <typename MBYTE>
 	void set_streak_loopfunc(bool bit, std::size_t& bitcount);
 	// Function that is looped inside the 'set_from' method
-	template <bool DIRECTION,typename MBYTE>
+	template <typename MBYTE>
 	void set_from_loopfunc(BitSequence& source, std::size_t& bitcount);
 	// Function that is nested inside the 'set_from' method
-	template <bool DIRECTION,std::size_t MAX_M>
+	template <std::size_t MAX_M>
 	void set_from_innerfunc(BitSequence& source, std::size_t bitcount);
 };
 

--- a/Implementation/Int Encoding/BitSequence_test.cpp
+++ b/Implementation/Int Encoding/BitSequence_test.cpp
@@ -7,13 +7,13 @@
 //using namespace BitSequence_NS;
 
 static const std::size_t SIZE = 16;
-static const bool ENDIAN = LITTLE;
+typedef BitSequence<true,false> BitSeq_t;
 
 /*******************************************************************************
  * TESTS - OPERATORS <<, >>
  ******************************************************************************/
 void BitSequence_test_inout_stress() {
-	std::cout << "Test Routine:\tBitSequence class" << std::endl;
+	std::cout << "Test suite:\tBitSequence class" << std::endl;
 	std::cout << "\ttarget:\toperator<<, operator>> methods" << std::endl;
 	std::cout << "\ttype:\tstress test" << std::endl;
 
@@ -22,7 +22,7 @@ void BitSequence_test_inout_stress() {
 	std::cout << "done." << std::endl;
 
 	bool test_status = true;
-	BitSequence<ENDIAN> bstream;
+	BitSeq_t bstream;
 	std::size_t pos_bit;
 	std::string bits_copy1, bits_copy2;
 	bool bit_next;
@@ -78,7 +78,7 @@ void BitSequence_test_inout_stress() {
  * TESTS - METHODS get_streak, set_streak
  ******************************************************************************/
 void BitSequence_test_getsetstreak_manual() {
-	std::cout << "Test Routine:\tBitSequence class" << std::endl;
+	std::cout << "Test suite:\tBitSequence class" << std::endl;
 	std::cout << "\ttarget:\tget_streak, set_streak methods" << std::endl;
 	std::cout << "\ttype:\tmanual input case test" << std::endl;
 
@@ -87,7 +87,7 @@ void BitSequence_test_getsetstreak_manual() {
 	std::cout << "done." << std::endl;
 
 	std::cout << "Instantiating BitSequence object... ";
-	BitSequence<ENDIAN> bstream(storage,storage+SIZE);
+	BitSeq_t bstream(storage,storage+SIZE);
 	std::cout << "done.\n" << std::endl;
 
 	std::size_t i=0;
@@ -154,7 +154,7 @@ void BitSequence_test_getsetstreak_manual() {
 
 
 void BitSequence_test_getsetstreak_stress() {
-	std::cout << "Test Routine:\tBitSequence class" << std::endl;
+	std::cout << "Test suite:\tBitSequence class" << std::endl;
 	std::cout << "\ttarget:\tget/set_streak methods" << std::endl;
 	std::cout << "\ttype:\tstress test" << std::endl;
 
@@ -163,7 +163,7 @@ void BitSequence_test_getsetstreak_stress() {
 	std::cout << "done." << std::endl;
 
 	bool test_status = true;
-	BitSequence<ENDIAN> bstream;
+	BitSeq_t bstream;
 	std::size_t pos_bit;
 	std::size_t len_bitrun;
 	std::string bits_copy1, bits_copy2;
@@ -227,18 +227,18 @@ void BitSequence_test_getsetstreak_stress() {
  * TESTS - METHODS get_to_int, set_from_int
  ******************************************************************************/
 void BitSequence_test_setfromint_predefrange() {
-	std::cout << "Test Routine:\tBitSequence class" << std::endl;
+	std::cout << "Test suite:\tBitSequence class" << std::endl;
 	std::cout << "\ttarget:\tset_from_int methods" << std::endl;
 	std::cout << "\ttype:\tpre-defined input range" << std::endl;
 
-	BitSequence<ENDIAN> bseq;
+	BitSeq_t bseq;
 	byte storage, n;
 	std::size_t bitlen;
 	bool bit;
 
 	std::cout << "Beginning test." << std::endl;
 	for (n=1; n != 0; ++n) {
-		bitlen = bit_pos(msb(n))+1;
+		bitlen = bit_pos_m2l(msb(n))+1;
 		std::cout << "Getting " << bitlen << " bits from int... ";
 		bseq.init(&storage, &storage+sizeof(byte));
 		bseq.set_from_int(n, bitlen);
@@ -259,11 +259,11 @@ void BitSequence_test_setfromint_predefrange() {
 
 template <typename MBYTE>
 void BitSequence_test_getsetint_predefrange() {
-	std::cout << "Test Routine:\tBitSequence class" << std::endl;
+	std::cout << "Test suite:\tBitSequence class" << std::endl;
 	std::cout << "\ttarget:\tget_to_int, set_from_int methods" << std::endl;
 	std::cout << "\ttype:\tpre-defined input range" << std::endl;
 
-	BitSequence<ENDIAN> bseq;
+	BitSeq_t bseq;
 	byte storage[sizeof(MBYTE)+1]{};
 	MBYTE n, n2;
 	std::size_t bitlen, offset;
@@ -272,7 +272,7 @@ void BitSequence_test_getsetint_predefrange() {
 	std::cout << "Beginning test." << std::endl;
 	for (n=1; n != 0; ++n) {
 		std::cout << "n  = " << (unsigned long long)n << std::endl;
-		bitlen = bit_pos(msb(n))+1;
+		bitlen = bit_pos_m2l(msb(n))+1;
 		offset = rand() % CHAR_BIT;
 		std::cout << "Setting " << bitlen << " bits from int... ";
 		bseq.init(storage, storage+sizeof(MBYTE)+1);
@@ -312,7 +312,7 @@ void BitSequence_test_getsetint_predefrange() {
  * TESTS - METHOD set_from
  ******************************************************************************/
 void BitSequence_test_setfrom_stress() {
- 	std::cout << "Test Routine:\tBitSequence class" << std::endl;
+ 	std::cout << "Test suite:\tBitSequence class" << std::endl;
  	std::cout << "\ttarget:\tset_from  method" << std::endl;
  	std::cout << "\ttype:\tstress test" << std::endl;
 
@@ -321,7 +321,7 @@ void BitSequence_test_setfrom_stress() {
  	std::cout << "done." << std::endl;
 
  	bool test_status = true;
-	BitSequence<ENDIAN> bstream, bstream2;
+	BitSeq_t bstream, bstream2;
 	std::size_t i, pos1_1, pos1_2, pos2;
 	std::string bits_copy_tmp, bits_copy1, bits_copy2;
 	bool bit_next;
@@ -408,10 +408,11 @@ void BitSequence_test_setfrom_stress() {
 
 
 int main() {
-	//BitSequence_test_inout_stress();
 	//BitSequence_test_getsetstreak_manual();
+
+	//BitSequence_test_inout_stress();
 	//BitSequence_test_getsetstreak_stress();
-	//BitSequence_test_setfromint_predefrange();
-	//BitSequence_test_getsetint_predefrange<unsigned short>();
 	//BitSequence_test_setfrom_stress();
+	//BitSequence_test_setfromint_predefrange();
+	BitSequence_test_getsetint_predefrange<unsigned short>();
 }

--- a/Implementation/Int Encoding/BitTwiddles.h
+++ b/Implementation/Int Encoding/BitTwiddles.h
@@ -2,7 +2,7 @@
 #define BITTWIDDLES_H
 
 template <typename MBYTE>
-MBYTE lsb(MBYTE value) {
+inline MBYTE lsb(MBYTE value) {
 	return value & -value;
 }
 template <typename MBYTE>
@@ -13,11 +13,10 @@ MBYTE msb(MBYTE value) {
 	return value^(value>>1);
 }
 
-template <typename MBYTE>
-static std::size_t bit_pos(MBYTE value) {
-	static const std::size_t pow2mod131_table[131] =
-	{
-		CHAR_BIT*sizeof(MBYTE),
+// TODO reduce size of hash table
+/*
+static const int pow2m1mod131_table_l2m[131] = {
+	// 2^n mod131 indices in comments:
 	//  0					5
 			0,	1,	72,	2,	46,	73,	96,	3,	14,	//0
 		47,	56,	74,	18,	97,	118,4,	43,	15,	35,	//10
@@ -32,9 +31,56 @@ static std::size_t bit_pos(MBYTE value) {
 		94,	54,	116,33,	21,	84,	27,	10,	88,	122,//100
 		103,113,100,80,	108,69,	53,	32,	83,	9,	//110
 		121,112,79,	68,	31,	8,	111,67,	7,	66,	//120
+		65,	130
+	};
+//*/
+template <typename MBYTE>
+static inline std::size_t bit_pos_l2m(MBYTE value) {
+	// TODO remove v table and use ^ table
+	static const int pow2mod131_table_l2m[131] = {
+		// 2^n mod131 indices in comments:
+			CHAR_BIT*sizeof(MBYTE),
+		//  0					5
+				0,	1,	72,	2,	46,	73,	96,	3,	14,	//0
+			47,	56,	74,	18,	97,	118,4,	43,	15,	35,	//10
+			48,	38,	57,	23,	75,	92,	19,	86,	98,	51,	//20
+			119,29,	5,	128,44,	12,	16,	41,	36,	90,	//30
+			49,	126,39,	124,58,	60,	24,	105,76,	62,	//40
+			93,	115,20,	26,	87,	102,99,	107,52,	82,	//50
+			120,78,	30,	110,6,	64,	129,71,	45,	95,	//60
+			13,	55,	17,	117,42,	34,	37,	22,	91,	85,	//70
+			50,	28,	127,11,	40,	89,	125,123,59,	104,//80
+			61,	114,25,	101,106,81,	77,	109,63,	70,	//90
+			94,	54,	116,33,	21,	84,	27,	10,	88,	122,//100
+			103,113,100,80,	108,69,	53,	32,	83,	9,	//110
+			121,112,79,	68,	31,	8,	111,67,	7,	66,	//120
+			65
+		};
+	return pow2mod131_table_l2m[CHAR_BIT*sizeof(MBYTE) > 8 ? value%131 : value];
+	//return pow2m1mod131_table_l2m[(value-MBYTE(1))%131];
+}
+
+static const int pow2mod131_table_m2l[131] = {
+	// 2^n mod131 indices in comments:
+	//  0					5
+		-1,	0,	1,	72,	2,	46,	73,	96,	3,	14,	//0
+		47,	56,	74,	18,	97,	118,4,	43,	15,	35,	//10
+		48,	38,	57,	23,	75,	92,	19,	86,	98,	51,	//20
+		119,29,	5,	128,44,	12,	16,	41,	36,	90,	//30
+		49,	126,39,	124,58,	60,	24,	105,76,	62,	//40
+		93,	115,20,	26,	87,	102,99,	107,52,	82,	//50
+		120,78,	30,	110,6,	64,	129,71,	45,	95,	//60
+		13,	55,	17,	117,42,	34,	37,	22,	91,	85,	//70
+		50,	28,	127,11,	40,	89,	125,123,59,	104,//80
+		61,	114,25,	101,106,81,	77,	109,63,	70,	//90
+		94,	54,	116,33,	21,	84,	27,	10,	88,	122,//100
+		103,113,100,80,	108,69,	53,	32,	83,	9,	//110
+		121,112,79,	68,	31,	8,	111,67,	7,	66,	//120
 		65
 	};
-	return pow2mod131_table[CHAR_BIT*sizeof(MBYTE) > 8 ? value%131 : value];
+template <typename MBYTE>
+static inline std::size_t bit_pos_m2l(MBYTE value) {
+	return pow2mod131_table_m2l[CHAR_BIT*sizeof(MBYTE) > 8 ? value%131 : value];
 }
 
 #endif

--- a/Implementation/Int Encoding/WholeNumSequence.h
+++ b/Implementation/Int Encoding/WholeNumSequence.h
@@ -9,16 +9,16 @@
 template <bool ENDIAN>
 class WholeNumSequence {
 private:
-	BitSequence<ENDIAN> bseq;
+	BitSequence<ENDIAN,false> bseq;
 
 public:
 	typedef unsigned long long wnum_t;
 	static std::size_t encoding_bitlength(wnum_t n);
 
 	explicit WholeNumSequence();
-	explicit WholeNumSequence(BitSequence<ENDIAN> bits);
-	void init(BitSequence<ENDIAN> bits);
-	BitSequence<ENDIAN> get_bit_sequence();
+	explicit WholeNumSequence(BitSequence<ENDIAN,false> bits);
+	void init(BitSequence<ENDIAN,false> bits);
+	BitSequence<ENDIAN,false> get_bit_sequence();
 
 	bool has_next() const;
 	void skip_next();

--- a/Implementation/Int Encoding/WholeNumSequence_cpp.h
+++ b/Implementation/Int Encoding/WholeNumSequence_cpp.h
@@ -6,15 +6,15 @@
 template <bool ENDIAN>
 WholeNumSequence<ENDIAN>::WholeNumSequence() {}
 template <bool ENDIAN>
-WholeNumSequence<ENDIAN>::WholeNumSequence(BitSequence<ENDIAN> bits)
+WholeNumSequence<ENDIAN>::WholeNumSequence(BitSequence<ENDIAN,false> bits)
 	: bseq(bits) {}
 
 template <bool ENDIAN>
-void WholeNumSequence<ENDIAN>::init(BitSequence<ENDIAN> bits) {
+void WholeNumSequence<ENDIAN>::init(BitSequence<ENDIAN,false> bits) {
 	bseq = bits;
 }
 template <bool ENDIAN>
-BitSequence<ENDIAN> WholeNumSequence<ENDIAN>::get_bit_sequence() {
+BitSequence<ENDIAN,false> WholeNumSequence<ENDIAN>::get_bit_sequence() {
 	return bseq;
 }
 
@@ -25,7 +25,7 @@ std::size_t WholeNumSequence<ENDIAN>::encoding_bitlength(wnum_t value) {
 	// Get significant variables
 	std::size_t pos_msb = msb(value);
 	const bool smsb = value & (pos_msb>>1);
-	pos_msb = bit_pos(pos_msb);
+	pos_msb = bit_pos_l2m(pos_msb);
 	// Check for sufficient bit storage
 	return 2*pos_msb + smsb - (value == 2);
 }
@@ -33,7 +33,7 @@ std::size_t WholeNumSequence<ENDIAN>::encoding_bitlength(wnum_t value) {
 
 template <bool ENDIAN>
 bool WholeNumSequence<ENDIAN>::has_next() const {
-	BitSequence<ENDIAN> bseq_copy(bseq);
+	BitSequence<ENDIAN,false> bseq_copy(bseq);
 	const std::size_t len_ones_prefix = bseq_copy.get_streak(true);
 	if (!bseq_copy.has_next(len_ones_prefix+1)) {
 		return false;
@@ -100,10 +100,10 @@ bool WholeNumSequence<ENDIAN>::set_next(wnum_t value) {
 	// Get significant variables
 	std::size_t pos_msb = msb(value);
 	const bool smsb = value & (pos_msb>>1);
-	pos_msb = bit_pos(pos_msb);
+	pos_msb = bit_pos_l2m(pos_msb);
 	// Check for sufficient bit storage
 	if (!bseq.has_next(2*pos_msb + smsb - (value == 2))) {
-		bseq.skip_next(-1); // skips to end of BitSequence<ENDIAN>
+		bseq.skip_next(-1); // skips to end of BitSequence
 		return false;
 	} else {
 		// Set bits


### PR DESCRIPTION
- added template parameter, 'bool BITS_L2M' to BitSequence class (true -> bits start from lsb, false -> bits start from msb)
    (changing this value also reverses byte order, to allow for contiguous grouping of bits into multi-byte words)
- added relational operators (>,<, a-b, ==) to BitSequence
- hard-coded WholeNumSequence to use 'BITS_L2M == false'
    (ensures that encoding is lexicographic, w/o having to reverse input integer bit order)
- other changes & improvements