### PR TITLE
Added SBS-Base classes & fixed issues across the board

### DIFF
--- a/Implementation/include/bit-encoding/BitSequence.hpp
+++ b/Implementation/include/bit-encoding/BitSequence.hpp
@@ -2,8 +2,7 @@
 #define BITSEQUENCE_H
 
 #include <cstddef>
-
-typedef unsigned char byte;
+#include <cstdint>
 
 /* CLASS: BitSequence
  *
@@ -94,9 +93,9 @@ private:
 		return ENDIAN_LITTLE == BITS_L2M;
 	}
 
-	byte subindex;
-	byte* p_index;
-	byte* p_end;
+	uint8_t subindex;
+	uint8_t* p_index;
+	uint8_t* p_end;
 
 	//template <typename MBYTE>
 	//static inline void apply_bits(MBYTE bits_from, MBYTE& bits_to, MBYTE mask);
@@ -135,9 +134,11 @@ private:
 public:
 	// TODO allow for initial offset
 	explicit BitSequence();
-	explicit BitSequence(byte* begin, byte* end);
-	//BitSequence(const BitSequence<ENDIAN>& rhs);
-	void init(byte* begin, byte* end);
+	explicit BitSequence(uint8_t* begin, uint8_t* end);
+	void init(uint8_t* begin, uint8_t* end);
+	
+	BitSequence(const BitSequence& rhs) = default;
+	BitSequence& operator=(const BitSequence& rhs) = default;
 
 	operator bool() const;
 	inline std::size_t bits_left() const;

--- a/Implementation/include/bit-utility/BitTwiddles.hpp
+++ b/Implementation/include/bit-utility/BitTwiddles.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <climits>
+#include <cstdint>
 
 // NOTE - algorithms based on
 //		https://graphics.stanford.edu/~seander/bithacks.html
@@ -23,7 +24,7 @@ MBYTE msb(MBYTE value) {
 // NOTE - canNOT exempt char from mod unless table size < 256
 //			(for char val = 0, val-1 == 255 -> canNOT fit in 128-width table)
 //		- thus, 128-width table only wastes space compared to 64-width
-static const unsigned char table_pow2m1mod131_0h[131] = {
+static const uint8_t table_pow2m1mod131_0h[131] = {
 	// 2^n mod131 indices in comments:
 	//  0                          5
 		       0,   1,  72,   2,  46,  73,  96,   3,  14,	//0
@@ -42,7 +43,7 @@ static const unsigned char table_pow2m1mod131_0h[131] = {
 		 65, 130
 	};
 /*/
-static const unsigned char table_pow2m1mod67_0h[67] {
+static const uint8_t table_pow2sub1mod67_0h[67] {
 	// 2^n mod67 indices in comments:
 	//  0                    5
 		     0,	 1, 39,  2, 15, 40, 23,  3, 12,	//0
@@ -55,15 +56,20 @@ static const unsigned char table_pow2m1mod67_0h[67] {
 	};
 //*/
 template <typename MBYTE>
-inline unsigned char bit_pos_0h(MBYTE value) {
-	static_assert(sizeof(MBYTE)*CHAR_BIT < 67,
-			"type width too large for table lookup");
+inline uint8_t bit_pos_0h(MBYTE value) {
+	static_assert(
+			sizeof(MBYTE)*CHAR_BIT < 67,
+			"type width too large for table lookup"
+		);
 	//return table_pow2m1mod131_0h[sizeof(MBYTE)*CHAR_BIT > 8 ? (value-1)%131 : value-1];
-	return table_pow2m1mod67_0h[(value-1)%67];
+	return table_pow2sub1mod67_0h[((MBYTE)(value-1)) % 67];
+		// MBYTE cast required
+		// otherwise uchar-1 -> char -> X
 }
 
+
 // Note - table size >= 128 allows for 'char'-type lookups w/o modulus operation
-static const signed char table_pow2mod131_0l[131] = {
+static const int8_t table_pow2mod131_0l[131] = {
 	// 2^n mod131 indices in comments:
 	//  0                          5
 		 -1,   0,   1,  72,   2,  46,  73,  96,  3,  14,	//0
@@ -82,14 +88,16 @@ static const signed char table_pow2mod131_0l[131] = {
 		 65
 	};
 template <typename MBYTE>
-inline signed char bit_pos_0l(MBYTE value) {
-	static_assert(sizeof(MBYTE)*CHAR_BIT <= 128,
-			"type width too large for table lookup");
+inline int8_t bit_pos_0l(MBYTE value) {
+	static_assert(
+			sizeof(MBYTE)*CHAR_BIT <= 128,
+			"type width too large for table lookup"
+		);
 	return table_pow2mod131_0l[sizeof(MBYTE)*CHAR_BIT > 8 ? value%131 : value];
 }
 
 template <typename MBYTE>
-inline signed char bit_pos(MBYTE value) {
+inline int8_t bit_pos(MBYTE value) {
 	return bit_pos_0l(value);
 }
 

--- a/Implementation/include/whole-num-encoding/WholeNumSeq_SBS1.hpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSeq_SBS1.hpp
@@ -1,24 +1,27 @@
 #ifndef WHOLENUMSEQ_SBS1_HPP
 #define WHOLENUMSEQ_SBS1_HPP
 
-#include "WholeNumSeq_Base.hpp"
+#include "WholeNumSeq_SBSBase.hpp"
 #include <cstdint>
 
 template <bool ENDIAN>
-class WholeNumSeqSBS1 : virtual public WholeNumSeqBase<ENDIAN> {
-public:
-	using WholeNumSeqBase<ENDIAN>::WholeNumSeqBase;
+class WholeNumSeqSBS1 : virtual protected WholeNumSeqSBSBase<ENDIAN> {
+private:
+	inline WholeNumSeqSBSBase<ENDIAN> sbsbase_copy_skip1bit() const;
 
-	static std::size_t encoding_bitlength(uintmax_t n);
+public:
+	using WholeNumSeqSBSBase<ENDIAN>::WholeNumSeqSBSBase;
+	using WholeNumSeqSBSBase<ENDIAN>::init;
+	using WholeNumSeqSBSBase<ENDIAN>::read_bit_sequence;
 
 	bool has_next() const;
-	void skip_next();
+	bool skip_next();
 	bool fits_next(const uintmax_t& value) const;
 
 	// TODO make >>, << throw exceptions, read/write_next not check
 	bool peek_next(uintmax_t& value) const;
 	bool read_next(uintmax_t& value);
-	bool write_next(uintmax_t value);
+	bool write_next(const uintmax_t& value);
 
 	WholeNumSeqSBS1& operator<<(const uintmax_t& u);
 	WholeNumSeqSBS1& operator>>(uintmax_t& u);

--- a/Implementation/include/whole-num-encoding/WholeNumSeq_SBS1.tpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSeq_SBS1.tpp
@@ -1,65 +1,45 @@
-
-#include "BitTwiddles.hpp"
 #include <stdexcept>
 
 template <bool ENDIAN>
-std::size_t WholeNumSeqSBS1<ENDIAN>::encoding_bitlength(uintmax_t value) {
-	// Excludes null cases
-	if (value <= 0) return -1;
-	// Handles small-value exception cases
-	else if (value <= 1) {
-		return 1;
-	}
-	// Handles general cases
-	value += 1;
-	//		Get significant variables
-	std::size_t pos_msb = msb(value);
-	const bool smsb = value & (pos_msb>>1);
-	pos_msb = bit_pos_0h(pos_msb);
-	//		Check for sufficient bit storage
-	return 2*pos_msb + smsb;
+WholeNumSeqSBSBase<ENDIAN> WholeNumSeqSBS1<ENDIAN>::sbsbase_copy_skip1bit() const {
+	BitSequence<ENDIAN,false> bseq_copy(this->bseq);
+	bseq_copy.skip_next();
+	return WholeNumSeqSBSBase<ENDIAN>(bseq_copy);
 }
+
+
+
 
 
 template <bool ENDIAN>
 bool WholeNumSeqSBS1<ENDIAN>::has_next() const {
-	BitSequence<ENDIAN,false> bseq_copy(this->bseq);
-	const std::size_t len_1s_prefix = bseq_copy.read_streak(true);
-	// Handles small-value exception cases
-	if (len_1s_prefix == 0) {
-		return bseq_copy.has_next(1);
-	}
-	// Handles general cases
-	//		Preliminary check (ensures skip_next() will not fail)
-	if (!bseq_copy.has_next(len_1s_prefix+1)) {
+	if (!this->bseq.has_next()) {
 		return false;
+	} else if (this->bseq.peek_next() == false) {
+		return true;
 	}
-	//		Gets second-most-sig-bit
-	bseq_copy.skip_next();
-	//		Decisive check (informed by second-most-sig-bit)
-	return !bseq_copy.peek_next() || bseq_copy.has_next(len_1s_prefix + 1);
+
+	return sbsbase_copy_skip1bit().skip_next();
 }
 template <bool ENDIAN>
-void WholeNumSeqSBS1<ENDIAN>::skip_next() {
-	const std::size_t len_1s_prefix = this->bseq.read_streak(true);
-	// Handles small-value exception cases
-	if (len_1s_prefix == 0) {
-		this->bseq.skip_next(1);
-		return;
+bool WholeNumSeqSBS1<ENDIAN>::skip_next() {
+	if (!this->bseq.has_next()) {
+		return false;
+	} else if (this->bseq.read_next() == false) {
+		return true;
 	}
-	// Handles general cases
-	//		Preliminary check (ensures skip_next() will not fail)
-	if (!this->bseq.has_next(len_1s_prefix+1)) {
-		this->bseq.skip_next(-1);
-		return;
-	}
-	//		Performs full skip (cannot fail with insufficient space)
-	this->bseq.skip_next();
-	this->bseq.skip_next(len_1s_prefix + this->bseq.peek_next());
+
+	return WholeNumSeqSBSBase<ENDIAN>::skip_next();
 }
 template <bool ENDIAN>
 bool WholeNumSeqSBS1<ENDIAN>::fits_next(const uintmax_t& value) const {
-	return this->bseq.has_next(encoding_bitlength(value));
+	if (value == 1) {
+		return this->bseq.has_next();
+	} else if (value == 0) {
+		throw std::domain_error("WholeNumSeqSBS1::fits_next");
+	}
+	
+	return sbsbase_copy_skip1bit().fits_next(value+1);
 }
 
 template <bool ENDIAN>
@@ -68,87 +48,46 @@ inline bool WholeNumSeqSBS1<ENDIAN>::peek_next(uintmax_t& value) const {
 }
 template <bool ENDIAN>
 bool WholeNumSeqSBS1<ENDIAN>::read_next(uintmax_t& value) {
-	// Get significant variables
-	const std::size_t len_1s_prefix = this->bseq.read_streak(true);
-	// Make preliminary check
-	if (!this->bseq.has_next(len_1s_prefix+1)) {
-		this->bseq.skip_next(-1);
+	if (!this->bseq.has_next()) {
+		return false;
+	} else if (this->bseq.read_next() == false) {
+		value = 1;
+		return true;
+	}
+
+	if (!WholeNumSeqSBSBase<ENDIAN>::read_next(value)) {
 		return false;
 	}
-	this->bseq.skip_next(); // guaranteed 0-bit
-	// Handles small-value exception cases
-	if (len_1s_prefix == 0) {
-		value = 1;
-	}
-	// Handle general cases
-	else {
-		// Get other significant variables
-		const bool smsb = !this->bseq.read_next();
-		const std::size_t pos_smsb = len_1s_prefix - smsb;
-		if (!this->bseq.has_next(pos_smsb)) {
-			this->bseq.skip_next(-1);
-			return false;
-		}
-		// Write bits to integer
-		value = 0;
-		this->bseq.read_to_int(value, pos_smsb);
-		value += (uintmax_t(2+smsb)<<(pos_smsb)) - 1;
-	}
+	--value;
 	return true;
 }
 
 template <bool ENDIAN>
-bool WholeNumSeqSBS1<ENDIAN>::write_next(uintmax_t value) {
-	// Handle null cases
+bool WholeNumSeqSBS1<ENDIAN>::write_next(const uintmax_t& value) {
 	if (value <= 0) {
 		throw std::domain_error("WholeNumSeqSBS1::write_next");
-	}
-
-	// Handle small-value exception cases
-	if (value <= 1) {
-		// Check for sufficient bit storage
-		if (!this->bseq.has_next(1)) {
-			this->bseq.skip_next(-1); // skips to end of BitSequence
-			return false;
-		}
-		// Set bits
-		this->bseq << false;
+	} else if (!this->bseq.has_next()) {
+		this->bseq.skip_next(-1); // skips to end of BitSequence
+		return false;
 	}
 	
-	// Handle general cases
-	else {
-		// Shifts value for general case
-		value += 1;
-		// Get significant variables
-		std::size_t pos_msb = msb(value);
-		const bool smsb = value & (pos_msb>>1);
-		pos_msb = bit_pos_0h(pos_msb);
-		// Check for sufficient bit storage
-		if (!this->bseq.has_next(2*pos_msb + smsb)) {
-			this->bseq.skip_next(-1); // skips to end of BitSequence
-			return false;
-		}
-		// Set bits
-		this->bseq.write_streak(true, pos_msb - !smsb);
-		this->bseq << false << !smsb;
-		this->bseq.write_from_int(value, pos_msb-1);
-		// Reverse any value shift
-		value -= 1;
-	}
-	return true;
+	this->bseq.write_next(value > 1);
+	return (value <= 1) || WholeNumSeqSBSBase<ENDIAN>::write_next(value+1);
 }
 
 template <bool ENDIAN>
 inline WholeNumSeqSBS1<ENDIAN>& WholeNumSeqSBS1<ENDIAN>::operator>>(uintmax_t& value) {
 	if (!read_next(value)) {
-		throw std::range_error("WholeNumSeqSBS1::operator>> - incomplete entry stored");
+		throw std::range_error("WholeNumSeqSBS1::operator>>"
+			" - incomplete entry stored");
 	}
 	return *this;
 }
 template <bool ENDIAN>
 inline WholeNumSeqSBS1<ENDIAN>& WholeNumSeqSBS1<ENDIAN>::operator<<(const uintmax_t& value) {
 	if (!write_next(value)) {
-		throw std::range_error("WholeNumSeqSBS1::operator<< - insufficient space for argument");
+		throw std::range_error("WholeNumSeqSBS1::operator<<"
+			" - insufficient space for argument");
 	}
 	return *this;
 }

--- a/Implementation/include/whole-num-encoding/WholeNumSeq_SBS2.hpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSeq_SBS2.hpp
@@ -1,24 +1,27 @@
 #ifndef WHOLENUMSEQ_SBS2_HPP
 #define WHOLENUMSEQ_SBS2_HPP
 
-#include "WholeNumSeq_Base.hpp"
+#include "WholeNumSeq_SBSBase.hpp"
 #include <cstdint>
 
 template <bool ENDIAN>
-class WholeNumSeqSBS2 : virtual public WholeNumSeqBase<ENDIAN> {
-public:
-	using WholeNumSeqBase<ENDIAN>::WholeNumSeqBase;
+class WholeNumSeqSBS2 : virtual protected WholeNumSeqSBSBase<ENDIAN> {
+private:
+	inline WholeNumSeqSBSBase<ENDIAN> sbsbase_copy_skip1bit() const;
 
-	static std::size_t encoding_bitlength(uintmax_t n);
+public:
+	using WholeNumSeqSBSBase<ENDIAN>::WholeNumSeqSBSBase;
+	using WholeNumSeqSBSBase<ENDIAN>::init;
+	using WholeNumSeqSBSBase<ENDIAN>::read_bit_sequence;
 
 	bool has_next() const;
-	void skip_next();
+	bool skip_next();
 	bool fits_next(const uintmax_t& value) const;
 
 	// TODO make >>, << throw exceptions, read/write_next not check
 	bool peek_next(uintmax_t& value) const;
 	bool read_next(uintmax_t& value);
-	bool write_next(uintmax_t value);
+	bool write_next(const uintmax_t& value);
 
 	WholeNumSeqSBS2& operator<<(const uintmax_t& u);
 	WholeNumSeqSBS2& operator>>(uintmax_t& u);

--- a/Implementation/include/whole-num-encoding/WholeNumSeq_SBS2.tpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSeq_SBS2.tpp
@@ -1,64 +1,46 @@
-
-#include "BitTwiddles.hpp"
 #include <stdexcept>
 
 template <bool ENDIAN>
-std::size_t WholeNumSeqSBS2<ENDIAN>::encoding_bitlength(uintmax_t value) {
-	// Excludes null cases
-	if (value <= 0) return -1;
-	// Handles small-value exception cases
-	else if (value <= 2) {
-		return 2;
-	}
-	// Handles general cases
-	//		Get significant variables
-	std::size_t pos_msb = msb(value);
-	const bool smsb = value & (pos_msb>>1);
-	pos_msb = bit_pos_0h(pos_msb);
-	//		Check for sufficient bit storage
-	return 2*pos_msb + smsb;
+WholeNumSeqSBSBase<ENDIAN> WholeNumSeqSBS2<ENDIAN>::sbsbase_copy_skip1bit() const {
+	BitSequence<ENDIAN,false> bseq_copy(this->bseq);
+	bseq_copy.skip_next();
+	return WholeNumSeqSBSBase<ENDIAN>(bseq_copy);
 }
+
+
+
 
 
 template <bool ENDIAN>
 bool WholeNumSeqSBS2<ENDIAN>::has_next() const {
-	BitSequence<ENDIAN,false> bseq_copy(this->bseq);
-	const std::size_t len_1s_prefix = bseq_copy.read_streak(true);
-	// Handles small-value exception cases
-	if (len_1s_prefix == 0) {
-		return bseq_copy.has_next(2);
-	}
-	// Handles general cases
-	//		Preliminary check (ensures skip_next() will not fail)
-	if (!bseq_copy.has_next(len_1s_prefix+1)) {
+	if (!this->bseq.has_next(2)) {
 		return false;
+	} else if (this->bseq.peek_next() == false) {
+		return true;
 	}
-	//		Gets second-most-sig-bit
-	bseq_copy.skip_next();
-	//		Decisive check (informed by second-most-sig-bit)
-	return !bseq_copy.peek_next() || bseq_copy.has_next(len_1s_prefix + 1);
+	
+	return sbsbase_copy_skip1bit().skip_next();
 }
 template <bool ENDIAN>
-void WholeNumSeqSBS2<ENDIAN>::skip_next() {
-	const std::size_t len_1s_prefix = this->bseq.read_streak(true);
-	// Handles small-value exception cases
-	if (len_1s_prefix == 0) {
-		this->bseq.skip_next(2);
-		return;
+bool WholeNumSeqSBS2<ENDIAN>::skip_next() {
+	if (!this->bseq.has_next(2)) {
+		return false;
+	} else if (this->bseq.read_next() == false) {
+		this->bseq.skip_next();
+		return true;
 	}
-	// Handles general cases
-	//		Preliminary check (ensures skip_next() will not fail)
-	if (!this->bseq.has_next(len_1s_prefix+1)) {
-		this->bseq.skip_next(-1);
-		return;
-	}
-	//		Performs full skip (cannot fail with insufficient space)
-	this->bseq.skip_next();
-	this->bseq.skip_next(len_1s_prefix + this->bseq.peek_next());
+
+	return WholeNumSeqSBSBase<ENDIAN>::skip_next();
 }
 template <bool ENDIAN>
 bool WholeNumSeqSBS2<ENDIAN>::fits_next(const uintmax_t& value) const {
-	return this->bseq.has_next(encoding_bitlength(value));
+	if (value == 0) {
+		throw std::domain_error("WholeNumSeqSBS2::fits_next");
+	} else if (value <= 2) {
+		return this->bseq.has_next(2);
+	}
+	
+	return sbsbase_copy_skip1bit().fits_next(value);
 }
 
 template <bool ENDIAN>
@@ -67,89 +49,49 @@ inline bool WholeNumSeqSBS2<ENDIAN>::peek_next(uintmax_t& value) const {
 }
 template <bool ENDIAN>
 bool WholeNumSeqSBS2<ENDIAN>::read_next(uintmax_t& value) {
-	// Get significant variables
-	const std::size_t len_1s_prefix = this->bseq.read_streak(true);
-	// Make preliminary check
-	if (!this->bseq.has_next(len_1s_prefix+1)) {
-		this->bseq.skip_next(-1);
+	if (!this->bseq.has_next(2)) {
 		return false;
-	}
-	this->bseq.skip_next(); // guaranteed 0-bit
-	// Handles small-value exception cases
-	if (len_1s_prefix == 0) {
-		if (!this->bseq.has_next()) {
-			this->bseq.skip_next(-1);
-			return false;
-		}
+	} else if (this->bseq.read_next() == false) {
 		value = 1 + this->bseq.read_next();
-	}
-	// Handle general cases
-	else {
-		// Get other significant variables
-		const bool smsb = !this->bseq.read_next();
-		const std::size_t pos_smsb = len_1s_prefix - smsb;
-		if (!this->bseq.has_next(pos_smsb)) {
-			this->bseq.skip_next(-1);
-			return false;
-		}
-		// Write bits to integer
-		value = 0;
-		this->bseq.read_to_int(value, pos_smsb);
-		value += (uintmax_t(2+smsb)<<(pos_smsb));
-	}
-	return true;
+		return true;
+	} 
+
+	return WholeNumSeqSBSBase<ENDIAN>::read_next(value);
 }
 
 template <bool ENDIAN>
-bool WholeNumSeqSBS2<ENDIAN>::write_next(uintmax_t value) {
-	// Handle null cases
+bool WholeNumSeqSBS2<ENDIAN>::write_next(const uintmax_t& value) {
 	if (value <= 0) {
 		throw std::domain_error("WholeNumSeqSBS2::write_next");
+	} else if (!this->bseq.has_next(2)) {
+		this->bseq.skip_next(-1); // skips to end of BitSequence
+		return false;
 	}
 
-	// Handle small-value exception cases
 	if (value <= 2) {
 		// Check for sufficient bit storage
-		if (!this->bseq.has_next(2)) {
-			this->bseq.skip_next(-1); // skips to end of BitSequence
-			return false;
-		}
-		// Set bits
-		this->bseq << false;
-		this->bseq << (value >= 2);
+		this->bseq.write_next(false);
+		this->bseq.write_next(value == 2);
+		return true;
+	} else {
+		this->bseq.write_next(true);
+		return WholeNumSeqSBSBase<ENDIAN>::write_next(value);
 	}
-	
-	// Handle general cases
-	else {
-		// Get significant variables
-		std::size_t pos_msb = msb(value);
-		const bool smsb = value & (pos_msb>>1);
-		pos_msb = bit_pos_0h(pos_msb);
-		// Check for sufficient bit storage
-		if (!this->bseq.has_next(2*pos_msb + smsb)) {
-			this->bseq.skip_next(-1); // skips to end of BitSequence
-			return false;
-		}
-		// Set bits
-		this->bseq.write_streak(true, pos_msb - !smsb);
-		this->bseq << false << !smsb;
-		this->bseq.write_from_int(value, pos_msb-1);
-		// Reverse any value shift
-	}
-	return true;
 }
 
 template <bool ENDIAN>
 inline WholeNumSeqSBS2<ENDIAN>& WholeNumSeqSBS2<ENDIAN>::operator>>(uintmax_t& value) {
 	if (!read_next(value)) {
-		throw std::range_error("WholeNumSeqSBS2::operator>> - incomplete entry stored");
+		throw std::range_error("WholeNumSeqSBS2::operator>>"
+			" - incomplete entry stored");
 	}
 	return *this;
 }
 template <bool ENDIAN>
 inline WholeNumSeqSBS2<ENDIAN>& WholeNumSeqSBS2<ENDIAN>::operator<<(const uintmax_t& value) {
 	if (!write_next(value)) {
-		throw std::range_error("WholeNumSeqSBS2::operator<< - insufficient space for argument");
+		throw std::range_error("WholeNumSeqSBS2::operator<<"
+			" - insufficient space for argument");
 	}
 	return *this;
 }

--- a/Implementation/include/whole-num-encoding/WholeNumSeq_SBSBase.hpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSeq_SBSBase.hpp
@@ -1,0 +1,27 @@
+#ifndef WHOLENUMSEQ_SBSBASE_HPP
+#define WHOLENUMSEQ_SBSBASE_HPP
+
+#include "WholeNumSeq_Base.hpp"
+#include <cstdint>
+
+template <bool ENDIAN>
+class WholeNumSeqSBSBase : public WholeNumSeqBase<ENDIAN> {
+public:
+	using WholeNumSeqBase<ENDIAN>::WholeNumSeqBase;
+
+	bool has_next() const;
+	bool skip_next();
+	bool fits_next(const uintmax_t& value) const;
+
+	// TODO make >>, << throw exceptions, read/write_next not check
+	bool peek_next(uintmax_t& value) const;
+	bool read_next(uintmax_t& value);
+	bool write_next(const uintmax_t& value);
+
+	WholeNumSeqSBSBase& operator<<(const uintmax_t& u);
+	WholeNumSeqSBSBase& operator>>(uintmax_t& u);
+};
+
+#include "WholeNumSeq_SBSBase.tpp"
+
+#endif

--- a/Implementation/include/whole-num-encoding/WholeNumSeq_SBSBase.tpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSeq_SBSBase.tpp
@@ -1,0 +1,114 @@
+#include "BitTwiddles.hpp"
+#include <stdexcept>
+
+template <bool ENDIAN>
+bool WholeNumSeqSBSBase<ENDIAN>::has_next() const {
+	BitSequence<ENDIAN,false> bseq_copy(this->bseq);
+	const std::size_t len_1s_prefix = bseq_copy.read_streak(true);
+	// Preliminary check (ensures skip_next() will not fail)
+	if (!bseq_copy.has_next(len_1s_prefix+2)) {
+		return false;
+	}
+	// Gets second-most-sig-bit
+	bseq_copy.skip_next();
+	// Decisive check (informed by second-most-sig-bit)
+	return !bseq_copy.peek_next() || bseq_copy.has_next(len_1s_prefix + 2);
+}
+template <bool ENDIAN>
+bool WholeNumSeqSBSBase<ENDIAN>::skip_next() {
+	const std::size_t len_1s_prefix = this->bseq.read_streak(true);
+	// Preliminary check (ensures skip_next() will not fail)
+	if (!this->bseq.has_next(len_1s_prefix+2)) {
+		this->bseq.skip_next(-1);
+		return false;
+	}
+	// Performs full skip (cannot fail with insufficient space)
+	this->bseq.skip_next(len_1s_prefix + 2 + this->bseq.peek_next());
+	return true;
+}
+template <bool ENDIAN>
+bool WholeNumSeqSBSBase<ENDIAN>::fits_next(const uintmax_t& value) const {
+	// Handle null cases
+	if (value <= 2) {
+		throw std::domain_error("WholeNumSeqSBSBase::write_next");
+	}
+	// Get significant variables
+	std::size_t pos_msb = msb(value);
+	const bool smsb = value & (pos_msb>>1);
+	pos_msb = bit_pos_0h(pos_msb);
+	// Check for sufficient bit storage
+	return this->bseq.has_next(2*pos_msb - !smsb);
+}
+
+template <bool ENDIAN>
+inline bool WholeNumSeqSBSBase<ENDIAN>::peek_next(uintmax_t& value) const {
+	return WholeNumSeqSBSBase<ENDIAN>(*this).read_next(value);
+}
+template <bool ENDIAN>
+bool WholeNumSeqSBSBase<ENDIAN>::read_next(uintmax_t& value) {
+	// Get significant variables
+	const std::size_t len_1s_prefix = this->bseq.read_streak(true);
+	// Make preliminary check
+	if (!this->bseq.has_next(len_1s_prefix+2)) {
+		this->bseq.skip_next(-1);
+		return false;
+	}
+	this->bseq.skip_next(); // guaranteed 0-bit after end of 1's streak
+	// Get other significant variables
+	const bool smsb = !this->bseq.read_next();
+	const std::size_t pos_smsb = len_1s_prefix + !smsb;
+
+	if (!this->bseq.has_next(pos_smsb)) {
+		this->bseq.skip_next(-1);
+		return false;
+	}
+	// Write bits to integer
+	value = 0;
+	this->bseq.read_to_int(value, pos_smsb);
+	value += (uintmax_t(2+smsb) << pos_smsb);
+	
+	return true;
+}
+
+template <bool ENDIAN>
+bool WholeNumSeqSBSBase<ENDIAN>::write_next(const uintmax_t& value) {
+	// Handle null cases
+	if (value <= 2) {
+		throw std::domain_error("WholeNumSeqSBSBase::write_next");
+	}
+
+	// Get significant variables
+	std::size_t pos_msb = msb(value);
+	const bool smsb = value & (pos_msb>>1);
+	pos_msb = bit_pos_0h(pos_msb);
+	
+	// Check for sufficient bit storage
+	if (!this->bseq.has_next(2*pos_msb + smsb - 1)) {
+		this->bseq.skip_next(-1); // skips to end of BitSequence
+		return false;
+	}
+	
+	// Set bits
+	this->bseq.write_streak(true, pos_msb + smsb - 2);
+	this->bseq << false << !smsb;
+	this->bseq.write_from_int(value, pos_msb-1);
+
+	return true;
+}
+
+template <bool ENDIAN>
+inline WholeNumSeqSBSBase<ENDIAN>& WholeNumSeqSBSBase<ENDIAN>::operator>>(uintmax_t& value) {
+	if (!this->read_next(value)) {
+		throw std::range_error("WholeNumSeqSBSBase::operator>>"
+			" - incomplete entry stored");
+	}
+	return *this;
+}
+template <bool ENDIAN>
+inline WholeNumSeqSBSBase<ENDIAN>& WholeNumSeqSBSBase<ENDIAN>::operator<<(const uintmax_t& value) {
+	if (!this->write_next(value)) {
+		throw std::range_error("WholeNumSeqSBSBase::operator<<"
+			" - insufficient space for argument");
+	}
+	return *this;
+}

--- a/Implementation/include/whole-num-encoding/WholeNumSequence.hpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSequence.hpp
@@ -23,8 +23,8 @@ private:
 	inline void update_rho(uintmax_t n);
 	
 public:
-	using WholeNumSeqBase<ENDIAN>::WholeNumSeqBase;
-	using WholeNumSeqBase<ENDIAN>::read_bit_sequence;
+	using WholeNumSeqSBSBase<ENDIAN>::WholeNumSeqSBSBase;
+	using WholeNumSeqSBSBase<ENDIAN>::read_bit_sequence;
 	
 	inline void init(BitSequence<ENDIAN,false> bits);
 

--- a/Implementation/include/whole-num-encoding/WholeNumSequence.tpp
+++ b/Implementation/include/whole-num-encoding/WholeNumSequence.tpp
@@ -1,33 +1,32 @@
-
-
-
 template <bool ENDIAN>
 bool WholeNumSequence<ENDIAN>::rho_lt_3div4() const {
 	return rho_region < GEQ_3DIV4;
 }
 template <bool ENDIAN>
 void WholeNumSequence<ENDIAN>::update_rho(uintmax_t a_n) {
-	// rho_n = (a_n + rho_(n-1)) ^ -1
-	rho_region = (
-			// (a_n <= 0) -> not permitted
-			(a_n == 1)
-				? (rho_region == EQ_0)
-					? EQ_1
-				: (rho_region == LEQ_1DIV3)
-					? GEQ_3DIV4
-					: IN_1DIV3_3DIV4
-			: (a_n == 2)
-				? (rho_region != EQ_1)
-					? IN_1DIV3_3DIV4
-					: LEQ_1DIV3
-			: (a_n == 3)
-				? (rho_region == EQ_0)
-					? IN_1DIV3_3DIV4
-					: LEQ_1DIV3
-			// (a_n > 3)
-				: LEQ_1DIV3
-		);
-	return;
+	//		rho_n = (a_n + rho_(n-1)) ^ -1
+
+	// (a_n <= 0) -> not permitted
+	
+	if (a_n == 1) {
+		if (rho_region == EQ_0)
+			rho_region = EQ_1;
+		else if (rho_region == LEQ_1DIV3)
+			rho_region = GEQ_3DIV4;
+		else
+			rho_region = IN_1DIV3_3DIV4;
+	}
+
+	else if (a_n == 2) {
+		if (rho_region < EQ_1)
+			rho_region = IN_1DIV3_3DIV4;
+		else
+			rho_region = LEQ_1DIV3;
+	}
+	
+	else { // if (a_n > 2)
+		rho_region = LEQ_1DIV3;
+	}
 }
 
 
@@ -69,24 +68,24 @@ inline bool WholeNumSequence<ENDIAN>::peek_next(uintmax_t& value) const {
 }
 template <bool ENDIAN>
 bool WholeNumSequence<ENDIAN>::read_next(uintmax_t& value) {
-	const bool successful = (rho_lt_3div4()
-		? WholeNumSeqSBS1<ENDIAN>::read_next(value)
-		: WholeNumSeqSBS2<ENDIAN>::read_next(value));
-	// Update rho & return
-	if (successful)
-		update_rho(value);
-	return successful;
+	if (!(rho_lt_3div4()
+			? WholeNumSeqSBS1<ENDIAN>::read_next(value)
+			: WholeNumSeqSBS2<ENDIAN>::read_next(value)))
+		return false;
+
+	update_rho(value);
+	return true;
 }
 
 template <bool ENDIAN>
 bool WholeNumSequence<ENDIAN>::write_next(uintmax_t value) {
-	const bool successful = (rho_lt_3div4()
-		? WholeNumSeqSBS1<ENDIAN>::write_next(value)
-		: WholeNumSeqSBS2<ENDIAN>::write_next(value));
-	// Update rho & return
-	if (successful)
-		update_rho(value);
-	return successful;
+	if (!(rho_lt_3div4()
+			? WholeNumSeqSBS1<ENDIAN>::write_next(value)
+			: WholeNumSeqSBS2<ENDIAN>::write_next(value)))
+		return false;
+	
+	update_rho(value);
+	return true;
 }
 
 template <bool ENDIAN>

--- a/Implementation/test/BitSequence_test.cpp
+++ b/Implementation/test/BitSequence_test.cpp
@@ -1,257 +1,213 @@
 #include "BitSequence.hpp"
+
+#include "BitTwiddles.hpp"
 #include <iostream>
 #include <string>
+#include <vector>
 #include <algorithm>
-#include "BitTwiddles.hpp"
+#include <exception>
+#include <limits>
 
 //using namespace BitSequence_NS;
 
 static const std::size_t SIZE = 16;
-typedef BitSequence<true,false> BitSeq_t;
+static constexpr bool ENDIAN = true;
+
+typedef BitSequence<ENDIAN,false> BitSeq_t;
 
 void cout_header(
 	std::string str_suite,
 	std::string str_target, 
 	std::string str_testtype)
 {
-	std::cout << "Test suite:\t" << str_suite << std::endl;
-	std::cout << "\ttarget:\t" << str_target << std::endl;
-	std::cout << "\ttype:\t" << str_testtype << std::endl;
+	std::cout << "==================================================\n"
+		<< "Test suite:\t" << str_suite << std::endl
+		<< "\ttarget:\t" << str_target << std::endl
+		<< "\ttype:\t" << str_testtype << std::endl;
+}
+
+
+std::string diffs(const std::string& str1, const std::string& str2) {
+	std::string diffs;
+	std::size_t i;
+	
+	for (i=0; i<std::min(str1.length(), str2.length()); ++i) {
+		diffs.push_back(str1[i] == str2[i] ? ' ' : '^');
+	}
+	for (; i<std::max(str1.length(), str2.length()); ++i) {
+		diffs.push_back('^');
+	}
+	
+	return diffs;
 }
 
 /*******************************************************************************
  * TESTS - OPERATORS <<, >>
  ******************************************************************************/
-void BitSequence_test_inout_stress() {
-	cout_header("BitSequence class", "operator<<, operator>> methods", "stress test");
+template <typename BitSeq_t>
+void BitSequence_test_inout_stress(
+		std::size_t storage_size = 1,
+		std::size_t max_test_count = -1
+	)
+{
+	cout_header(
+		"BitSequence class", 
+		"operator<<, operator>> methods", 
+		"stress test"
+		);
 
-	std::cout << "Allocating " << SIZE << " bytes in memory... ";
-	byte storage[SIZE]{};
-	std::cout << "done." << std::endl;
+	std::vector<uint8_t> storage(storage_size, 0xFF);
 
-	bool test_status = true;
-	BitSeq_t bstream;
+	BitSeq_t bseq;
 	std::size_t pos_bit;
-	std::string bits_copy1, bits_copy2;
+	std::string bits_strcopy1, bits_strcopy2;
 	bool bit_next;
 
 	std::cout << std::noboolalpha;
-	while (test_status) {
+
+	std::size_t test_counter;
+	for (test_counter = 0; test_counter < max_test_count; ++test_counter) {
 		pos_bit = 0;
-		bstream.init(storage,storage+SIZE);
-		bits_copy1.clear();
-		while (test_status && pos_bit < CHAR_BIT*SIZE) {
+		bseq.init(storage.data(), storage.data()+storage.size());
+		bits_strcopy1.clear();
+		while (pos_bit < CHAR_BIT*storage.size()) {
 			bit_next = rand()%2;
-			bstream << bit_next;
-			bits_copy1.push_back(bit_next ? '1':'0');
+			bseq << bit_next;
+			bits_strcopy1.push_back(bit_next ? '1':'0');
 			pos_bit += 1;
 		}
 
 		pos_bit = 0;
-		bstream.init(storage,storage+SIZE);
-		bits_copy2.clear();
-		while (bstream.has_next() && pos_bit < CHAR_BIT*SIZE) {
-			bstream >> bit_next;
-			bits_copy2.push_back(bit_next ? '1':'0');
+		bseq.init(storage.data(), storage.data()+storage.size());
+		bits_strcopy2.clear();
+		while (bseq.has_next() && pos_bit < CHAR_BIT*storage.size()) {
+			bseq >> bit_next;
+			bits_strcopy2.push_back(bit_next ? '1':'0');
 			pos_bit += 1;
 		}
 
-		std::cout << "Bits in  = " << bits_copy1 << std::endl;
-		if (bits_copy1 == bits_copy2) {
-			std::cout << "Success! (Bits out = bits in)" << std::endl;
-		} else {
-			test_status = false;	// Test case failed!
-			std::size_t i;
-			std::cout << "Bits out = " << bits_copy2 << std::endl;
-			std::cout << "Diffs   -> ";
-			for (i=0; i<std::min(bits_copy1.length(), bits_copy2.length()); ++i)
-				std::cout << (bits_copy1[i] == bits_copy2[i] ? " " : "^");
-			for (; i<std::max(bits_copy1.length(), bits_copy2.length()); ++i)
-				std::cout << "^";
-			std::cout << std::endl;
-
-			std::cout << "Bits stored = ";
-			for (std::size_t i=0; i<SIZE; ++i) {
-				std::cout << std::hex << (unsigned short)(storage[i]);
-			}
-			std::cout << std::dec << std::endl;
+		if (bits_strcopy1 != bits_strcopy2) {
+			throw std::logic_error(
+					std::string("read/write bits do not match;\n")
+					+ bits_strcopy1 + std::string("\n")
+					+ bits_strcopy2 + std::string("\n")
+					+ diffs(bits_strcopy1, bits_strcopy2)
+				);
 		}
 	}
-	std::cout << std::boolalpha << "Ending Test." << std::endl;
+	std::cout << std::boolalpha << test_counter << " tests passed!" << std::endl;
 	return;
 }
 
 
 /*******************************************************************************
- * TESTS - METHODS get_streak, set_streak
+ * TESTS - METHODS read_streak, write_streak
  ******************************************************************************/
-void BitSequence_test_getsetstreak_manual() {
-	cout_header("BitSequence class", "get_streak, set_streak methods",
-		"manual input case test");
+template <typename BitSeq_t>
+void test_BitSequence_readwritestreak_single(
+	const std::vector<std::size_t>& streaks,
+	std::size_t storage_size
+	)
+{
+	static std::vector<uint8_t> storage;
+	static std::vector<std::size_t> streaks_copy;
+	static BitSeq_t bseq;
 
-	std::cout << "Allocating " << SIZE << " bytes in memory... ";
-	byte storage[SIZE]{};
-	std::cout << "done." << std::endl;
+	storage.assign(storage_size, 0xFF);
+	streaks_copy.clear();
+	streaks_copy.reserve(streaks.size());
 
-	std::cout << "Instantiating BitSequence object... ";
-	BitSeq_t bstream(storage,storage+SIZE);
-	std::cout << "done.\n" << std::endl;
-
-	std::size_t i=0;
-	std::ptrdiff_t i_tmp;
-	std::size_t j_tmp;
-	std::string bits_copy1;
-	while (true) {
-		if (i>=CHAR_BIT*SIZE) {
-			std::cout << "Storage capacity reached. Terminating input loop."
-					<< std::endl;
-			break;
-		}
-		std::cout << "(Empty bits remaining: " << CHAR_BIT*SIZE-i << ")\n";
-		std::cout << "Repetition length of bit to add = ";
-		std::cin.clear();
-		std::cin >> i_tmp;
-		//if (!) {
-		//	std::cout << "\nInvalid input" << std::endl;
-		//	continue;
-		//}
-		//std::cout << std::endl;
-		i_tmp = std::min<std::ptrdiff_t>(i_tmp, CHAR_BIT*SIZE-i);
-		if (i_tmp <= 0) {
-			std::cout << "Terminating input loop." << std::endl;
-			break;
-		}
-		std::cout << "Bit to add = ";
-		std::cin.clear();
-		std::cin >> j_tmp;
-		//if (!std::cin >> j_tmp) {
-		//	std::cout << "\nInvalid input" << std::endl;
-		//	continue;
-		//}
-		//std::cout << std::endl;
-
-		bstream.set_streak(j_tmp, i_tmp);
-		bits_copy1.append(i_tmp, j_tmp ? '1':'0');
-		i += i_tmp;
+	bseq.init(storage.data(), storage.data()+storage.size());
+	for (std::size_t i=0; i < streaks.size(); ++i) {
+		bseq.write_streak(i%2, streaks[i]);
 	}
 
-	std::cout << "Outputting bits from BitSequence... " << std::endl;
-
-	bstream.init(storage,storage+SIZE);
-	std::string bits_copy2;
-	std::size_t s_tmp;
-	bool b_tmp=true;
-	while (bstream.has_next() && i>0) {
-		s_tmp = bstream.get_streak(b_tmp,i);
-		bits_copy2.append(s_tmp,b_tmp ? '1':'0');
-		i-=s_tmp;
-		b_tmp = !b_tmp;
+	bseq.init(storage.data(), storage.data()+storage.size());
+	while (bseq.has_next()) {
+		streaks_copy.push_back(
+			bseq.read_streak(streaks_copy.size() % 2));
 	}
 
-	std::cout << "Bits in  = " << bits_copy1 << std::endl;
-	if (bits_copy1 == bits_copy2) {
-		std::cout << "Success! (Bits out = bits in)" << std::endl;
-	} else {
-		std::cout << "Bits out = " << bits_copy2 << std::endl;
+	if (!std::equal(streaks.begin(), streaks.end()-1, streaks_copy.begin())
+		|| CHAR_BIT*storage_size != std::accumulate(
+			streaks_copy.begin(), streaks_copy.end(), 0))
+	{
+		throw std::logic_error(
+				std::string("read/write bit streaks do not match;\n")
+			);
 	}
-
-	std::cout << "Ending Test." << std::endl;
-	return;
 }
 
+template <typename BitSeq_t>
+void BitSequence_test_readwritestreak_stress(
+		std::size_t storage_size = 1,
+		std::size_t max_test_count = -1
+	)
+{
+	cout_header(
+			"BitSequence class",
+			"read/write_streak methods",
+			"stress test"
+		);
 
-void BitSequence_test_getsetstreak_stress() {
-	cout_header("BitSequence class", "get/set_streak methods", "stress test");
-
-	std::cout << "Allocating " << SIZE << " bytes in memory... ";
-	byte storage[SIZE]{};
-	std::cout << "done." << std::endl;
-
-	bool test_status = true;
-	BitSeq_t bstream;
-	std::size_t pos_bit;
-	std::size_t len_bitrun;
-	std::string bits_copy1, bits_copy2;
-	bool bit_next = true;
-
-	std::cout << std::noboolalpha << "Begin test." << std::endl;
-	while (test_status) {
-		std::cout << "Setting bits in collections of monotone sequences...";
-		pos_bit = 0;
-		bstream.init(storage,storage+SIZE);
-		bits_copy1.clear();
-		while (test_status && pos_bit < CHAR_BIT*SIZE) {
-			len_bitrun = std::min<std::size_t>(1+rand()%10, CHAR_BIT*SIZE - pos_bit);
-
-			bstream.set_streak(bit_next, len_bitrun);
-			bits_copy1.append(len_bitrun, bit_next ? '1':'0');
-
-			bit_next = !bit_next;
-			pos_bit += len_bitrun;
-		}
-		std::cout << "done." << std::endl;
-
-		std::cout << "Reading bits in collections of monotone sequences...";
-		pos_bit = 0;
-		bstream.init(storage, storage+SIZE);
-		bits_copy2.clear();
-		while (bstream.has_next() && pos_bit < CHAR_BIT*SIZE) {
-			len_bitrun = bstream.get_streak(bit_next);
-			bits_copy2.append(len_bitrun, bit_next ? '1':'0');
-			pos_bit += len_bitrun;
-			bit_next = !bit_next;
-		}
-		std::cout << "done." << std::endl;
-
-		std::cout << "Bits in  = " << bits_copy1 << std::endl;
-		if (bits_copy1 == bits_copy2) {
-			std::cout << "Success! (Bits out = bits in)" << std::endl;
-		} else {
-			test_status = false;	// Test case failed!
-			std::size_t i;
-			std::cout << "Bits out = " << bits_copy2 << std::endl;
-			std::cout << "Diffs   -> ";
-			for (i=0; i<std::min(bits_copy1.length(), bits_copy2.length()); ++i)
-				std::cout << (bits_copy1[i] == bits_copy2[i] ? " " : "^");
-			for (; i<std::max(bits_copy1.length(), bits_copy2.length()); ++i)
-				std::cout << "^";
-			std::cout << std::endl;
-
-			std::cout << "Bits stored = ";
-			for (std::size_t i=0; i<SIZE; ++i) {
-				std::cout << std::hex << (unsigned short)(storage[i]);
-			}
-			std::cout << std::dec << std::endl;
-		}
-	}
-	std::cout << std::boolalpha << "Ending Test." << std::endl;
-	return;
-}
-
-/*******************************************************************************
- * TESTS - METHODS get_to_int, set_from_int
- ******************************************************************************/
-void BitSequence_test_setfromint_predefrange() {
-	cout_header("BitSequence class", "set_from_int methods", "pre-defined input range");
+	std::vector<uint8_t> storage(storage_size, 0xFF);
 
 	BitSeq_t bseq;
-	byte storage, n;
+	std::size_t len_bitrun;
+	std::vector<std::size_t> streaks;
+
+	std::cout << std::noboolalpha;
+	
+	std::size_t test_counter;
+	for (test_counter = 0; test_counter < max_test_count; ++test_counter) {
+		// Randomizes initial bit in sequence
+		if (rand() % 2) {
+			streaks.push_back(0);
+		}
+
+		for (std::size_t pos_bit=0; pos_bit < CHAR_BIT*storage.size();
+			pos_bit += len_bitrun)
+		{
+			len_bitrun = 1 + rand()%10;
+			streaks.push_back(len_bitrun);
+		}
+
+		test_BitSequence_readwritestreak_single<BitSeq_t>(streaks, storage_size);
+		streaks.clear();
+	}
+	std::cout << std::boolalpha << test_counter << " tests passed!" << std::endl;
+	return;
+}
+
+/*******************************************************************************
+ * TESTS - METHODS read_to_int, write_from_int
+ ******************************************************************************/
+template <typename BitSeq_t>
+void BitSequence_test_writefromint_predefrange() {
+	cout_header(
+			"BitSequence class",
+			"write_from_int methods",
+			"pre-defined input range"
+		);
+
+	BitSeq_t bseq;
+	uint8_t storage, n;
 	std::size_t bitlen;
 	bool bit;
 
-	std::cout << "Beginning test." << std::endl;
+	//std::cout << "Beginning test." << std::endl;
 	for (n=1; n != 0; ++n) {
 		bitlen = bit_pos_0l(msb(n))+1;
-		std::cout << "Getting " << bitlen << " bits from int... ";
-		bseq.init(&storage, &storage+sizeof(byte));
-		bseq.set_from_int(n, bitlen);
-		std::cout << "done." << std::endl;
+		//std::cout << "Getting " << bitlen << " bits from int... ";
+		bseq.init(&storage, &storage+sizeof(uint8_t));
+		bseq.write_from_int(n, bitlen);
+		//std::cout << "done." << std::endl;
 
-		std::cout << "n = " << (unsigned long long)n << "\tbseq = ";
-		bseq.init(&storage, &storage+sizeof(byte));
+		//std::cout << "n = " << (unsigned long long)n << "\tbseq = ";
+		bseq.init(&storage, &storage+sizeof(uint8_t));
 		while(bitlen-- > 0) {
 			bseq >> bit;
-			std::cout << (bit ? '1':'0');
+		//	std::cout << (bit ? '1':'0');
 		}
 		std::cout << std::endl;
 	}
@@ -260,159 +216,189 @@ void BitSequence_test_setfromint_predefrange() {
 	return;
 }
 
-template <typename MBYTE>
-void BitSequence_test_getsetint_predefrange() {
-	cout_header("BitSequence class", "get_to_int, set_from_int methods",
-		"pre-defined input range");
+template <typename BitSeq_t, typename MBYTE>
+void BitSequence_test_readwriteint_predefrange(
+		std::size_t storage_size = 1
+	) {
+	cout_header(
+			"BitSequence class",
+			"read_to_int, write_from_int methods",
+			"pre-defined input range"
+		);
 
 	BitSeq_t bseq;
-	byte storage[sizeof(MBYTE)+1]{};
+	std::vector<uint8_t> storage(storage_size, 0xFF);
 	MBYTE n, n2;
 	std::size_t bitlen, offset;
 	bool bit;
 
-	std::cout << "Beginning test." << std::endl;
 	for (n=1; n != 0; ++n) {
-		std::cout << "n  = " << (unsigned long long)n << std::endl;
 		bitlen = bit_pos_0l(msb(n))+1;
 		offset = rand() % CHAR_BIT;
-		std::cout << "Setting " << bitlen << " bits from int... ";
-		bseq.init(storage, storage+sizeof(MBYTE)+1);
-		bseq.skip_next(offset);
-		bseq.set_from_int(n, bitlen);
-		std::cout << "done." << std::endl;
 
-		std::cout << "Setting new int bits from storage... ";
+		bseq.init(storage.data(), storage.data()+storage.size());
+		bseq.skip_next(offset);
+		bseq.write_from_int(n, bitlen);
+
 		n2 = 0;
-		bseq.init(storage, storage+sizeof(MBYTE)+1);
+		bseq.init(storage.data(), storage.data()+storage.size());
 		bseq.skip_next(offset);
-		bseq.get_to_int(n2, bitlen);
-		std::cout << "done." << std::endl;
+		bseq.read_to_int(n2, bitlen);
 
-		if (n == n2) {
-			std::cout << "Pass! (new int == old int)" << std::endl;
-		} else {
-			std::cout << "Failure!" << std::endl;
-			std::cout << "n2 = " << n2 << std::endl;
-			std::cout << "storage bits = ";
-			bseq.init(storage, storage+sizeof(MBYTE)+1);
-			bseq.skip_next(offset);
-			while(bitlen-- > 0) {
-				bseq >> bit;
-				std::cout << (bit ? '1':'0');
-			}
-			std::cout << std::endl;
-			break;
+		if (n != n2) {
+			throw std::logic_error(
+					std::string("read/write bits do not match;\n")
+					//+ std::string(n) + std::string("\n")
+					//+ std::string(n2) + std::string("\n")
+				);
+			//std::cout << "storage bits = ";
+			//bseq.init(storage, storage+sizeof(MBYTE)+1);
+			//bseq.skip_next(offset);
+			//while(bitlen-- > 0) {
+			//	bseq >> bit;
+			//	std::cout << (bit ? '1':'0');
+			//}
+			//std::cout << std::endl;
+			//break;
 		}
 	}
 
-	std::cout << "Ending Test." << std::endl;
+	std::cout << MBYTE(-1) + 0u << " tests passed." << std::endl;
 	return;
 }
 
 /*******************************************************************************
- * TESTS - METHOD set_from
+ * TESTS - METHOD write_from
  ******************************************************************************/
-void BitSequence_test_setfrom_stress() {
-	cout_header("BitSequence class", "set_from  method", "stress test");
+template <typename BitSeq_t>
+void BitSequence_test_writefrom_stress(
+		std::size_t storage_size = 1,
+		std::size_t max_test_count = -1
+	)
+{
+	cout_header("BitSequence class", "write_from  method", "stress test");
 
- 	std::cout << "Allocating " << SIZE << " bytes in memory... ";
- 	byte storage[SIZE]{};
- 	std::cout << "done." << std::endl;
+	std::vector<uint8_t> storage(storage_size, 0xFF);
 
- 	bool test_status = true;
-	BitSeq_t bstream, bstream2;
+	BitSeq_t bseq, bseq2;
 	std::size_t i, pos1_1, pos1_2, pos2;
-	std::string bits_copy_tmp, bits_copy1, bits_copy2;
+	std::string bits_strcopy_tmp, bits_strcopy1, bits_strcopy2;
 	bool bit_next;
 
 	// Populate stream with random bits
-	bstream.init(storage,storage+SIZE);
-	for (i=0; i < CHAR_BIT*SIZE; ++i) {
+	bseq.init(storage.data(), storage.data()+storage.size());
+	for (i=0; i < CHAR_BIT*storage.size(); ++i) {
 		bit_next = rand()%2;
-		bstream << bit_next;
+		bseq << bit_next;
 	}
+
 	// Run stress test
 	std::cout << std::noboolalpha;
-	while (test_status) {
+	
+	std::size_t test_counter;
+	for (test_counter = 0; test_counter < max_test_count; ++test_counter) {
 		// Choose a random source range & destination
-		pos1_1 = rand() % (CHAR_BIT*SIZE);
-		pos1_2 = rand() % (CHAR_BIT*SIZE);
+		pos1_1 = rand() % (CHAR_BIT*storage.size());
+		pos1_2 = rand() % (CHAR_BIT*storage.size());
 		if (pos1_1 > pos1_2)
 			std::swap(pos1_1,pos1_2);
 		else
 			++pos1_2;
-		pos2 = rand() % (CHAR_BIT*SIZE+1 - (pos1_2-pos1_1));
-		std::cout << "Copy range source  = [" << pos1_1 << ", " << pos1_2 << ")"
-				<< std::endl;
-		std::cout << "Copy position dest = [" << pos2 << ", "
-				<< pos2 + pos1_2-pos1_1 << ")" << std::endl;
+		pos2 = rand() % (CHAR_BIT*storage.size()+1 - (pos1_2-pos1_1));
+
+		//std::cout << "Copy range source  = [" << pos1_1 << ", " << pos1_2 << ")"
+		//		<< std::endl;
+		//std::cout << "Copy position dest = [" << pos2 << ", "
+		//		<< pos2 + pos1_2-pos1_1 << ")" << std::endl;
+		
 		// Directly check current bits
-		bstream.init(storage,storage+SIZE);
-		for (i=0; i < CHAR_BIT*SIZE; ++i) {
-			bstream >> bit_next;
-			bits_copy1.push_back(bit_next ? '1':'0');
+		bseq.init(storage.data(), storage.data()+storage.size());
+		for (i=0; i < CHAR_BIT*storage.size(); ++i) {
+			bseq >> bit_next;
+			bits_strcopy1.push_back(bit_next ? '1':'0');
 		}
-		std::cout << "Source bits          = " << bits_copy1 << std::endl;
+		//std::cout << "Source bits          = " << bits_strcopy1 << std::endl;
+		
 		// Assign bits from stream 1 to 2
-		bits_copy_tmp = bits_copy1;
+		bits_strcopy_tmp = bits_strcopy1;
 		for (i=0; i < pos1_2-pos1_1; ++i) {
-			bits_copy1[pos2+i] = bits_copy_tmp[pos1_1+i];
- 		}
-		std::cout << "Expected result bits = " << bits_copy1 << std::endl;
-		bstream.init(storage,storage+SIZE);
-		bstream.skip_next(pos1_1);
-		bstream2.init(storage,storage+SIZE);
-		bstream2.skip_next(pos2);
-		bstream2.set_from(bstream, pos1_2-pos1_1);
+			bits_strcopy1[pos2+i] = bits_strcopy_tmp[pos1_1+i];
+		}
+		//std::cout << "Expected result bits = " << bits_strcopy1 << std::endl;
+		
+		bseq.init(storage.data(), storage.data()+storage.size());
+		bseq.skip_next(pos1_1);
+		bseq2.init(storage.data(), storage.data()+storage.size());
+		bseq2.skip_next(pos2);
+		bseq2.write_from(bseq, pos1_2-pos1_1);
+		
 		// Directly check resulting bitstream contents
-		bstream.init(storage,storage+SIZE);
-		for (i=0; i < CHAR_BIT*SIZE; ++i) {
-			bstream >> bit_next;
-			bits_copy2.push_back(bit_next ? '1':'0');
+		bseq.init(storage.data(), storage.data()+storage.size());
+		for (i=0; i < CHAR_BIT*storage.size(); ++i) {
+			bseq >> bit_next;
+			bits_strcopy2.push_back(bit_next ? '1':'0');
 		}
 
 		// Check results
- 		if (bits_copy1 == bits_copy2) {
- 			std::cout << "Success! (Expected result matches true result)\n"
-					<< std::endl;
-			// Populate previous source range with random bits
-			bstream.init(storage,storage+SIZE);
-			bstream.skip_next(pos1_1);
-			for (i=pos1_1; i < pos1_2; ++i) {
-				bit_next = rand()%2;
-	 			bstream << bit_next;
-	 		}
- 		} else {
- 			test_status = false;	// Test case failed!
-			std::cout << "True result bits     = " << bits_copy2 << std::endl;
- 			std::cout << "Diffs               -> ";
- 			for (i=0; i<std::min(bits_copy1.length(), bits_copy2.length()); ++i)
- 				std::cout << (bits_copy1[i] == bits_copy2[i] ? " " : "^");
- 			for (; i<std::max(bits_copy1.length(), bits_copy2.length()); ++i)
- 				std::cout << "^";
- 			std::cout << std::endl;
+		if (bits_strcopy1 != bits_strcopy2) {
+			throw std::logic_error(
+					std::string("read/write bits do not match;\n")
+					+ bits_strcopy1 + std::string("\n")
+					+ bits_strcopy2 + std::string("\n")
+					+ diffs(bits_strcopy1, bits_strcopy2)
+				);
+		}
 
- 			std::cout << "Bytes stored = ";
- 			for (i=0; i<SIZE; ++i) {
- 				std::cout << std::hex << (unsigned short)(storage[i]);
- 			}
- 			std::cout << std::dec << std::endl << std::endl;
- 		}
-		bits_copy1.clear();
-		bits_copy2.clear();
- 	}
- 	std::cout << std::boolalpha << "Ending Test." << std::endl;
- 	return;
+		bits_strcopy1.clear();
+		bits_strcopy2.clear();
+		// Populate previous source range with random bits
+		bseq.init(storage.data(), storage.data()+storage.size());
+		bseq.skip_next(pos1_1);
+		for (i=pos1_1; i < pos1_2; ++i) {
+			bit_next = rand()%2;
+			bseq << bit_next;
+		}
+	}
+	std::cout << std::boolalpha << test_counter << " tests passed!" << std::endl;
+	return;
  }
 
 
-int main() {
-	//BitSequence_test_getsetstreak_manual();
 
-	//BitSequence_test_inout_stress();
-	//BitSequence_test_getsetstreak_stress();
-	//BitSequence_test_setfrom_stress();
-	//BitSequence_test_setfromint_predefrange();
-	//BitSequence_test_getsetint_predefrange<unsigned short>();
+
+
+void test_runall(std::size_t storage_size, std::size_t test_counter) {
+	
+	// Single bit in/out
+	BitSequence_test_inout_stress<BitSequence<ENDIAN, false> >(
+		storage_size, test_counter);
+	BitSequence_test_inout_stress<BitSequence<ENDIAN, true> >(
+		storage_size, test_counter);
+
+	// Streak read/write
+	BitSequence_test_readwritestreak_stress<BitSequence<ENDIAN, false> >(
+		storage_size, test_counter);
+	BitSequence_test_readwritestreak_stress<BitSequence<ENDIAN, true> >(
+		storage_size, test_counter);
+
+	// Write bits from integer
+	//BitSequence_test_writefromint_predefrange<BitSequence<ENDIAN, false> >();
+	//BitSequence_test_writefromint_predefrange<BitSequence<ENDIAN, true> >();
+
+	// Read/write bits from integer
+	BitSequence_test_readwriteint_predefrange<BitSequence<ENDIAN, false>, uint8_t>(
+		storage_size);
+	BitSequence_test_readwriteint_predefrange<BitSequence<ENDIAN, true>, uint8_t>(
+		storage_size);
+
+	// Exchange between (possibly intersecting) streams
+	BitSequence_test_writefrom_stress<BitSequence<ENDIAN, false> >(
+		storage_size, test_counter);
+	BitSequence_test_writefrom_stress<BitSequence<ENDIAN, true> >(
+		storage_size, test_counter);
+
+}
+
+int main() {
+	test_runall(5, 100000);
 }

--- a/Implementation/test/BitTwiddles_test.cpp
+++ b/Implementation/test/BitTwiddles_test.cpp
@@ -98,7 +98,7 @@ void test_bit_pos_0h() {
 
 int main() {
 	//test_msb(32);
-	//test_bit_pos_0l();
+	test_bit_pos_0l();
 	test_bit_pos_0h();
 	return 0;
 }

--- a/Implementation/test/WholeNumSequence_test.cpp
+++ b/Implementation/test/WholeNumSequence_test.cpp
@@ -1,41 +1,48 @@
-// TODO remove after testing
-//#define public private
+#include "WholeNumSeq_SBSBase.hpp"
+#include "WholeNumSeq_SBS1.hpp"
+#include "WholeNumSeq_SBS2.hpp"
+#include "WholeNumSequence.hpp"
 
 #include "BitSequence.hpp"
-#include "WholeNumSequence.hpp"
 #include <iostream>
+#include <exception>
 #include <vector>
 #include <algorithm>
 
+static void cout_test_header(
+		const std::string& str_title, 
+		const std::string& str_target,
+		const std::string& str_type) {
+	std::cout << "Test Routine:\t" << str_title << std::endl;
+	std::cout << "\ttarget:\t\t" << str_target << std::endl;
+	std::cout << "\ttype:\t\t" << str_type << std::endl;
+}
+
 //using namespace BitSequence_NS;
-static const std::size_t SIZE = 64;
-static const bool ENDIAN = true;
-static const std::vector<std::string> BITS_BY_NO({	// for msb-to-lsb sequences
-	"0",		// 1
-	"100",		// 2
-	"1010",		// 3
-	"1011",		// 4
-	"11000",	// 5
-	"11001",	// 6
-	"110100",	// 7
-	"110101",	// 8
-	"110110",	// 9
-	"110111",	// 10
-	"1110000",	// 11
-	"1110001",	// 12
-	"1110010",	// 13
-	"1110011",	// 14
-	"11101000",	// 15
-	"11101001",	// 16
-	"11101010",	// 17
-	"11101011",	// 18
-	"11101100",	// 19
-	"11101101",	// 20
-	"11101110",	// 21
-	"11101111"	// 22
-});
+static constexpr std::size_t SIZE = 64;
+static constexpr bool ENDIAN = true;
+
 typedef BitSequence<ENDIAN,false> BitSeq_t;
-typedef WholeNumSequence<ENDIAN> WholeNumSeq_t;
+typedef WholeNumSequence<ENDIAN> WholeNumSeqt;
+
+template <typename WNSeq_t>
+std::string class_name();
+template <>
+std::string class_name<WholeNumSeqSBSBase<ENDIAN> >() {
+	return "WholeNumSeq_SBSBase";
+}
+template <>
+std::string class_name<WholeNumSeqSBS1<ENDIAN> >() {
+	return "WholeNumSeq_SBS1";
+}
+template <>
+std::string class_name<WholeNumSeqSBS2<ENDIAN> >() {
+	return "WholeNumSeq_SBS2";
+}
+template <>
+std::string class_name<WholeNumSequence<ENDIAN> >() {
+	return "WholeNumSequence";
+}
 
 /*******************************************************************************
  * TESTS - encoding_bitlength
@@ -52,7 +59,7 @@ void WholeNumSequence_test_encoding_bitlength_predefrange() {
     std::cout << "Beginning test." << std::endl;
     for (n=1; true; ++n) {
         std::cout << "n = " << n << '\t';
-        bitlength = WholeNumSeq_t::encoding_bitlength(n);
+        bitlength = WholeNumSeqt::encoding_bitlength(n);
         if (bitlength <= CHAR_BIT*SIZE) {
             std::cout << "bit length = " << bitlength << '\t' << std::endl;
         } else {
@@ -67,16 +74,17 @@ void WholeNumSequence_test_encoding_bitlength_predefrange() {
 * TESTS - Methods has_next, peek_next, skip_next
 *******************************************************************************/
 
+/*
 void WholeNumSequence_test_haspeekskipnext_stress() {
 	std::cout << "Test Routine:\tWholeNumSequence class" << std::endl;
 	std::cout << "\ttarget:\tmethods has_next, peek_next, skip_next" << std::endl;
 	std::cout << "\ttype:\tstress test" << std::endl;
 
 	std::cout << "Allocating " << SIZE << " bytes in memory... ";
-	byte storage[SIZE];
+	uint8_t storage[SIZE];
 	std::cout << "done." << std::endl;
 
-    WholeNumSeq_t wseq;
+    WholeNumSeqt wnseq;
 	BitSeq_t bseq;
     std::vector<uintmax_t> wnums_copy1, wnums_copy2;
     uintmax_t n;
@@ -104,10 +112,10 @@ void WholeNumSequence_test_haspeekskipnext_stress() {
         std::cout << "\ndone." << std::endl;
         // Retrieve all numbers from stream
         std::cout << "Reading output list from stream...";
-        wseq.init(BitSeq_t(storage, storage+SIZE));
-        while (wseq.has_next()) {
-			wseq.peek_next(n);
-			wseq.skip_next();
+        wnseq.init(BitSeq_t(storage, storage+SIZE));
+        while (wnseq.has_next()) {
+			wnseq.peek_next(n);
+			wnseq.skip_next();
 			wnums_copy2.push_back(n);
         }
         std::cout << "done." << std::endl;
@@ -136,118 +144,399 @@ void WholeNumSequence_test_haspeekskipnext_stress() {
     }
     std::cout << "Exiting test." << std::endl;
 }
+//*/
 
 
 
 /*******************************************************************************
-* TESTS - Methods read_next, write_next
+* READ/WRITE UTILITIES
+*******************************************************************************/
+// Test/stubbing constructs
+static const std::vector<std::string> SBSBASE_TABLE({
+	// for msb-first sequences
+	"00",		// 3
+	"010",		// 4
+	"011",		// 5
+	"1000",		// 6
+	"1001",		// 7
+	"10100",	// 8
+	"10101",	// 9
+	"10110",	// 10
+	"10111",	// 11
+	"110000",	// 12
+	"110001",	// 13
+	"110010",	// 14
+	"110011",	// 15
+	"1101000",	// 16
+	"1101001",	// 17
+	"1101010",	// 18
+	"1101011",	// 19
+	"1101100",	// 20
+	"1101101",	// 21
+	"1101110",	// 22
+	"1101111"	// 23
+});
+
+template <typename WNSeq_t>
+uintmax_t first_symbol() {
+	return 1;
+}
+template <>
+uintmax_t first_symbol<WholeNumSeqSBSBase<ENDIAN> >() {
+	return 3;
+}
+
+template <typename WNSeq_t>
+bool has_static_encoding(uintmax_t val);
+template <>
+bool has_static_encoding<WholeNumSeqSBSBase<ENDIAN> >(uintmax_t val) {
+	return val-3 < SBSBASE_TABLE.size();
+}
+template <>
+bool has_static_encoding<WholeNumSeqSBS1<ENDIAN> >(uintmax_t val) {
+	return val-1 < SBSBASE_TABLE.size() + 1;
+}
+template <>
+bool has_static_encoding<WholeNumSeqSBS2<ENDIAN> >(uintmax_t val) {
+	return val-1 < SBSBASE_TABLE.size() + 2;
+}
+
+bool has_static_encoding(uintmax_t val, bool ENC_SBS1) {
+	return val-1 < SBSBASE_TABLE.size() + 1 + !ENC_SBS1;
+}
+
+
+
+
+
+template <typename WNSeq_t>
+std::string encoding_str(uintmax_t val);
+template <>
+std::string encoding_str<WholeNumSeqSBSBase<ENDIAN> >(uintmax_t val) {
+	return SBSBASE_TABLE[val-3];
+}
+template <>
+std::string encoding_str<WholeNumSeqSBS1<ENDIAN> >(uintmax_t val) {
+	return (val == 1) ? "0" : (std::string("1") + SBSBASE_TABLE[val-2]);
+}
+template <>
+std::string encoding_str<WholeNumSeqSBS2<ENDIAN> >(uintmax_t val) {
+	return (val == 1) ? "00"
+		: ((val == 2) ? "01"
+		: (std::string("1") + SBSBASE_TABLE[val-3]));
+}
+
+std::string encoding_str(uintmax_t val, bool ENC_SBS1) {
+	//if (!has_static_encoding(val,ENC_SBS1))
+	//	return "";
+	
+	if (ENC_SBS1 && val <= 1)
+		return "0";
+	if (!ENC_SBS1 && val <= 2)
+		return (val == 1) ? "00" : "01";
+
+	return std::string("1") + SBSBASE_TABLE.at(val + ENC_SBS1 - 3);
+}
+
+
+
+
+class RhoTracker {
+public:
+	std::pair<uintmax_t, uintmax_t> rho_frac{0,1};
+
+	inline void push_back(uintmax_t next_val) {
+		//rho = 1 / (rho + next_val);
+		rho_frac = {
+				rho_frac.second,
+				rho_frac.first + rho_frac.second * next_val
+			};
+	}
+	inline bool should_use_SBS1() {
+		//return (rho < .75);
+		return rho_frac.first * 4 < rho_frac.second * 3;
+	}
+};
+
+
+/*******************************************************************************
+* READ/WRITE FUNCTIONS
 *******************************************************************************/
 
-void WholeNumSequence_test_writenext_predefrange() {
-	std::cout << "Test Routine:\tWholeNumSequence class" << std::endl;
-	std::cout << "\ttarget:\twrite_next method" << std::endl;
-	std::cout << "\ttype:\tpre-defined input range" << std::endl;
+bool write_bits_from_str(
+		BitSeq_t& bit_seq,
+		const std::string& bits_str
+	)
+{
+	if (!bit_seq.has_next(bits_str.length()))
+		return false;
 
-	WholeNumSeq_t wseq;
-	BitSeq_t bseq;
-	std::size_t n, offset;
-	byte storage[2]{255,255};
-	std::string bits_copy;
-	bool test_status = true;
-
-	std::cout << "Begin Test." << std::endl;
-	for (n = 1; test_status && n <= BITS_BY_NO.size(); ++n) {
-		std::cout << "n = " << n << std::endl;
-		for (offset = 0; test_status && offset < CHAR_BIT; ++offset) {
-			std::cout << "Setting number in sequence at offset "
-					<< offset << "... ";
-			storage[0] = storage[1] = 255;
-			bseq.init(storage, storage+2);
-			bseq.skip_next(offset);
-			wseq.init(bseq);
-			if (!wseq.write_next(n)) {
-				std::cout << "error: insufficient room to store no." << std::endl;
-				test_status = false;
-				break;
-			}
-			std::cout << "done." << std::endl;
-
-			std::cout << "Comparing bits to expected value... ";
-			bseq.init(storage, storage+2);
-			bseq.skip_next(offset);
-			bits_copy.clear();
-			while (bseq.has_next()) {
-				bits_copy.push_back(bseq.read_next() ? '1':'0');
-			}
-
-			if (BITS_BY_NO[n-1] != bits_copy.substr(
-					0, BITS_BY_NO[n-1].size())
-				) {
-				std::cout << "Failed. Bits stored:" << std::endl
-						<< bits_copy << std::endl;
-				std::cout << "Bits expected:" << std::endl
-						<< BITS_BY_NO[n-1] << std::endl;
-				test_status = false;
-				break;
-			}
-			std::cout << "Passed (stored = expected)" << std::endl;
-		}
+	for (auto iter = bits_str.begin(); iter < bits_str.end(); ++iter) {
+		bit_seq << (*iter == '1');
 	}
-	std::cout << "Test " << (test_status ? "passed!" : "failed.") << std::endl;
-	std::cout << "Exiting test." << std::endl;
+	return true;
 }
+bool read_bits_to_str(
+		BitSeq_t& bit_seq,
+		std::string& bits_str,
+		std::size_t length
+	)
+{
+	if (!bit_seq.has_next(length))
+		return false;
 
-void WholeNumSequence_test_readnext_predefrange() {
-	std::cout << "Test Routine:\tWholeNumSequence class" << std::endl;
-	std::cout << "\ttarget:\tread_next method" << std::endl;
-	std::cout << "\ttype:\tpre-defined input range" << std::endl;
-
-	WholeNumSeq_t wseq;
-	BitSeq_t bseq;
-	std::size_t n, offset;
-	uintmax_t n2;
-	byte storage[2]{255,255};
-	bool test_status = true;
-
-	std::cout << "Begin Test." << std::endl;
-	for (n = 1; test_status && n <= BITS_BY_NO.size(); ++n) {
-		std::cout << "n = " << n << std::endl;
-		for (offset = 0; test_status && offset < CHAR_BIT; ++offset) {
-			std::cout << "Setting bits directly in sequence at offset "
-					<< offset << "... ";
-			storage[0] = storage[1] = 255;
-			bseq.init(storage, storage+2);
-			bseq.skip_next(offset);
-			for (char c : BITS_BY_NO[n-1]) {
-				bseq.write_next(c == '1');
-			}
-			std::cout << "done." << std::endl;
-
-			std::cout << "Reading bits as number... ";
-			bseq.init(storage, storage+2);
-			bseq.skip_next(offset);
-			wseq.init(bseq);
-			if (!wseq.read_next(n2)) {
-				std::cout << "error: failed to read no." << std::endl;
-				test_status = false;
-				break;
-			}
-			std::cout << "done." << std::endl;
-
-			std::cout << "Comparing number to expected value... ";
-			if (n != n2) {
-				std::cout << "Failed.\n\tn2 = " << n2 << std::endl;
-				test_status = false;
-				break;
-			}
-			std::cout << "Passed (read = expected)" << std::endl;
-		}
+	for (std::size_t i = 0; i < length; ++i) {
+		bits_str.append(bit_seq.read_next() ? "1" : "0");
 	}
-	std::cout << "Test " << (test_status ? "passed!" : "failed.") << std::endl;
-	std::cout << "Exiting test." << std::endl;
+	return true;
 }
 
 
+
+
+
+template <typename WNSeq_t>
+bool write_bits_from_seq(
+		BitSeq_t& bit_seq,
+		const std::vector<uintmax_t>& seq
+	)
+{
+	for (auto iter = seq.begin(); iter < seq.end(); ++iter) {
+		if (
+				!has_static_encoding<WNSeq_t>(*iter)
+				|| !write_bits_from_str(bit_seq, encoding_str<WNSeq_t>(*iter))
+			)
+			return false;
+	}
+	return true;
+}
+
+template <typename WNSeq_t>
+bool check_nums_against_wnumseq(
+		WNSeq_t& wnseq, 
+		const std::vector<uintmax_t>& seq
+	)
+{
+	uintmax_t num;
+	for (auto iter_nums = seq.begin(); iter_nums < seq.end(); ++iter_nums) {
+		if (!wnseq.read_next(num) || *iter_nums != num)
+			return false;
+	}
+	return true;
+}
+
+
+
+template <typename WNSeq_t>
+bool write_nums_to_wnumseq(
+		WNSeq_t& wnseq,
+		const std::vector<uintmax_t>& seq
+	)
+{
+	for (auto iter = seq.begin(); iter < seq.end(); ++iter) {
+		if (!has_static_encoding<WNSeq_t>(*iter) || !wnseq.write_next(*iter))
+			return false;
+	}
+	return true;
+}
+
+template <typename WNSeq_t>
+bool check_bits_against_seq(
+		BitSeq_t& bit_seq,
+		const std::vector<uintmax_t>& seq
+	)
+{
+	std::string bits_str, bits_str_expected;
+
+	for (auto iter = seq.begin(); iter < seq.end(); ++iter) {
+		bits_str.clear();
+		bits_str_expected = encoding_str<WNSeq_t>(*iter);
+		if (!read_bits_to_str(bit_seq, bits_str, bits_str_expected.length())
+				|| bits_str != bits_str_expected)
+			return false;
+	}
+	return true;
+}
+
+
+
+
+
+
+
+template <>
+bool write_bits_from_seq<WholeNumSequence<ENDIAN> >(
+		BitSeq_t& bit_seq,
+		const std::vector<uintmax_t>& seq
+	)
+{
+	RhoTracker tracker;
+	for (auto iter = seq.begin(); iter < seq.end(); ++iter) {
+		if (
+				!has_static_encoding(*iter, tracker.should_use_SBS1())
+				|| !write_bits_from_str(bit_seq, encoding_str(*iter, tracker.should_use_SBS1()))
+			)
+			return false;
+		tracker.push_back(*iter);
+	}
+	return true;
+}
+
+
+template <>
+bool write_nums_to_wnumseq<WholeNumSequence<ENDIAN> >(
+	WholeNumSequence<ENDIAN>& wnseq, const std::vector<uintmax_t>& seq)
+{
+	RhoTracker tracker;
+	for (auto iter = seq.begin(); iter < seq.end(); ++iter) {
+		if (
+				!has_static_encoding(*iter, tracker.should_use_SBS1())
+				|| !wnseq.write_next(*iter)
+			)
+			return false;
+		tracker.push_back(*iter);
+	}
+	return true;
+}
+template <>
+bool check_bits_against_seq<WholeNumSequence<ENDIAN> >(
+	BitSeq_t& bit_seq, const std::vector<uintmax_t>& seq)
+{
+	RhoTracker tracker;
+	std::string bits_str, bits_str_expected;
+
+	for (auto iter = seq.begin(); iter < seq.end(); ++iter) {
+		bits_str.clear();
+		bits_str_expected = encoding_str(*iter, tracker.should_use_SBS1());
+		if (
+				!read_bits_to_str(bit_seq, bits_str, bits_str_expected.length())
+				|| bits_str != bits_str_expected
+			) 
+			return false;
+		tracker.push_back(*iter);
+	}
+	return true;
+}
+
+
+
+
+/*******************************************************************************
+* TESTS - read_next
+*******************************************************************************/
+
+template <typename WNSeq_t>
+bool test_WholeNumSeq_readnext(
+		const std::vector<uintmax_t>& vals,
+		std::size_t storage_size = 1
+	)
+{
+	static std::vector<uint8_t> storage;
+	storage.assign(storage_size, 0xFF);
+
+	BitSeq_t bseq(storage.data(), storage.data()+storage.size());
+	if (!write_bits_from_seq<WNSeq_t>(bseq, vals)) {
+		return false;
+	}
+
+	WNSeq_t wnseq(BitSeq_t(storage.data(), storage.data()+storage.size()));
+	if (!check_nums_against_wnumseq(wnseq, vals)) {
+		throw std::logic_error(
+			"read values do not match original sequence");
+	}
+
+	return true;
+}
+
+template <typename WNSeq_t>
+void WholeNumSequence_test_readnext_predefrange(std::size_t storage_size) {
+	cout_test_header(
+			class_name<WNSeq_t>() + " class",
+			"read_next method",
+			"pre-defined input range"
+		);
+
+	std::size_t test_case_counter = 0;
+
+	std::vector<uintmax_t> v_nums;
+	std::vector<uintmax_t>::iterator iter_nums;
+
+	while(true) {
+		v_nums.push_back(first_symbol<WNSeq_t>());
+		
+		while (!test_WholeNumSeq_readnext<WNSeq_t>(v_nums, storage_size)) {
+			v_nums.pop_back();
+			if (v_nums.empty()) {	
+				std::cout << test_case_counter << " test cases passed!\n"
+					<< std::endl;
+				return;
+			}
+			++(v_nums.back());
+		}
+		++test_case_counter;
+	}
+}
+
+
+/*******************************************************************************
+* TESTS - write_next
+*******************************************************************************/
+
+template <typename WNSeq_t>
+bool test_WholeNumSeq_writenext(
+		const std::vector<uintmax_t>& vals,
+		std::size_t storage_size = 1
+	)
+{
+	static std::vector<uint8_t> storage;
+	storage.assign(storage_size, 0xFF);
+
+	WNSeq_t wnseq(BitSeq_t(storage.data(), storage.data() + storage.size()));
+	if (!write_nums_to_wnumseq<WNSeq_t>(wnseq, vals)){
+		return false;
+	}
+
+	BitSeq_t bseq(storage.data(), storage.data()+storage.size());
+	if (!check_bits_against_seq<WNSeq_t>(bseq, vals)) {
+		throw std::logic_error(
+			"written values do not match original sequence");
+	}
+
+	return true;
+}
+
+template <typename WNSeq_t>
+void WholeNumSequence_test_writenext_predefrange(std::size_t storage_size) {
+	cout_test_header(
+			class_name<WNSeq_t>() + " class",
+			"write_next method",
+			"pre-defined input range"
+		);
+
+	std::size_t test_case_counter = 0;
+
+	std::vector<uintmax_t> v_nums;
+	std::vector<uintmax_t>::iterator iter_nums;
+
+	while(true) {
+		v_nums.push_back(first_symbol<WNSeq_t>());
+		
+		while (!test_WholeNumSeq_writenext<WNSeq_t>(v_nums, storage_size)) {
+			v_nums.pop_back();
+			if (v_nums.empty()) {	
+				std::cout << test_case_counter << " test cases passed!\n" << std::endl;
+				return;
+			}
+			++(v_nums.back());
+		}
+		++test_case_counter;
+	}
+}
+
+
+
+
+template <typename WNSeq_t>
 void WholeNumSequence_test_readwritenext_stress() {
     std::cout << "Test Routine:\tWholeNumSequence class" << std::endl;
  	std::cout << "\ttargets: operators <<, >>; has_next/fits_next methods"
@@ -255,10 +544,10 @@ void WholeNumSequence_test_readwritenext_stress() {
  	std::cout << "\ttype:\tstress" << std::endl;
 
     std::cout << "Allocating " << SIZE << " bytes in memory... ";
-	byte storage[SIZE];
+	uint8_t storage[SIZE];
 	std::cout << "done." << std::endl;
 
-    WholeNumSeq_t wseq;
+    WNSeq_t wnseq;
     std::vector<uintmax_t> wnums_copy1, wnums_copy2;
     uintmax_t n;
     std::size_t i;
@@ -272,17 +561,17 @@ void WholeNumSequence_test_readwritenext_stress() {
 		wnums_copy2.clear();
         // Fill number stream with random numbers
 		std::cout << "Generating/storing random inputs..." << std::endl;
-        wseq.init(BitSeq_t(storage, storage+SIZE));
+        wnseq.init(BitSeq_t(storage, storage+SIZE));
         while (n = 1 + (rand() % (uintmax_t(1)<<std::min(SIZE, std::size_t(3)))),//CHAR_BIT*sizeof(uintmax_t)-1))),
-				wseq.write_next(n)) {
+				wnseq.write_next(n)) {
             std::cout << '\t' << n << ',';
             wnums_copy1.push_back(n);
         }
         std::cout << "\ndone." << std::endl;
         // Retrieve all numbers from stream
         std::cout << "Reading output list from stream...";
-        wseq.init(BitSeq_t(storage, storage+SIZE));
-        while (wseq.read_next(n)) {
+        wnseq.init(BitSeq_t(storage, storage+SIZE));
+        while (wnseq.read_next(n)) {
             wnums_copy2.push_back(n);
         }
         std::cout << "done." << std::endl;
@@ -313,11 +602,29 @@ void WholeNumSequence_test_readwritenext_stress() {
 }
 
 
-int main() {
-	//WholeNumSequence_test_encoding_bitlength_predefrange();
+void test_runall() {
+	test_WholeNumSeq_readnext<WholeNumSequence<ENDIAN> >(
+		{3, 1, 1, 1, 1, 1, 1, 1, 1, 2}, 2);
 
-	WholeNumSequence_test_writenext_predefrange();
-	WholeNumSequence_test_readnext_predefrange();
-    //WholeNumSequence_test_readwritenext_stress();
-	//WholeNumSequence_test_haspeekskipnext_stress();
+	std::cout << "==============================================\n";
+	WholeNumSequence_test_readnext_predefrange<WholeNumSeqSBSBase<ENDIAN> >(2);
+	WholeNumSequence_test_writenext_predefrange<WholeNumSeqSBSBase<ENDIAN> >(2);
+
+	std::cout << "==============================================\n";
+	WholeNumSequence_test_readnext_predefrange<WholeNumSeqSBS1<ENDIAN> >(2);
+	WholeNumSequence_test_writenext_predefrange<WholeNumSeqSBS1<ENDIAN> >(2);
+
+	std::cout << "==============================================\n";
+	WholeNumSequence_test_readnext_predefrange<WholeNumSeqSBS2<ENDIAN> >(2);
+	WholeNumSequence_test_writenext_predefrange<WholeNumSeqSBS2<ENDIAN> >(2);
+
+	std::cout << "==============================================\n";
+	WholeNumSequence_test_readnext_predefrange<WholeNumSequence<ENDIAN> >(2);
+	WholeNumSequence_test_writenext_predefrange<WholeNumSequence<ENDIAN> >(2);
+	
+	std::cout << "==============================================" << std::endl;
+}
+
+int main() {
+	test_runall();
 }


### PR DESCRIPTION
- SBS-base class wraps inductive SBS behavior together, for use in SBS1/2
- added tests for SBS-base

WholeNum fixes:
- revised tests
- fixed various problems in WholeNum implementations (default constructors, rho-region tracker, etc.)

BitTwiddles fixes:
- fixed implicit casting issue
- TODO - revise BitTwiddles tests to run for multiple word sizes

BitSequence fixes
- fixed overlap check in BitSequence::write_from 
- minor stylistic revisions

Other fixes
- changed `unsigned char` to `uint8_t` & `signed char` to `int8_t` across the board
- (likely) other minor edits elsewhere